### PR TITLE
Enable geogram::gfx for testing purposes.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ elseif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 	set(VORPALINE_PLATFORM Darwin-clang-dynamic CACHE STRING "" FORCE)
 endif()
 
-option(GEOGRAM_WITH_GRAPHICS        "Viewers and geogram_gfx library"                                        OFF)
+option(GEOGRAM_WITH_GRAPHICS        "Viewers and geogram_gfx library"                                         ON)
 option(GEOGRAM_WITH_LEGACY_NUMERICS "Legacy numerical libraries"                                             OFF)
 option(GEOGRAM_WITH_HLBFGS          "Non-linear solver (Yang Liu's HLBFGS)"                                   ON)
 option(GEOGRAM_WITH_TETGEN          "Tetrahedral mesher (Hang Si's TetGen)"                                  OFF)
@@ -41,6 +41,7 @@ option(GEOGRAM_USE_SYSTEM_GLFW3     "Use the version of GLFW3 installed in the s
 
 include(GeogramMain.cmake)
 add_library(geogram::geogram ALIAS geogram)
+add_library(geogram::gfx ALIAS geogram_gfx)
 target_include_directories(geogram SYSTEM PUBLIC ${GEOGRAM_SOURCE_INCLUDE_DIR})
 
 ################################################################################


### PR DESCRIPTION
I'm using `geogram_gfx` in a small GUI tool for testing TUR-2138, so I'd like to enable it by default. On the geogram side this will add compilation of glfw/imgui, but since they are added with `add_subdirectory( ... EXCLUDE_FROM_ALL)` this should not affect people who are not building the tests. (We may need to organize the targets in the VS explorer panel though.)

Another caveat: current builds will have the option `GEOGRAM_WITH_GRAPHICS=OFF` right now. People will need to either remove their `CMakeCache.txt`, or toggle the option manually, otherwise `test_navigation` (see [turbo/#1566](https://github.com/nTopology/turbo/pull/1566)) it will complain. I can add a line in the CMake to force this option to true to ease the transition so that people won't notice, but we should remove it after a week or two.