### PR TITLE
Fix data races in parallel algos (TUR-2353).

### DIFF
--- a/src/lib/geogram/CMakeLists.txt
+++ b/src/lib/geogram/CMakeLists.txt
@@ -34,12 +34,14 @@ include_directories(${PROJECT_BINARY_DIR}/src/lib)
 
 add_library(geogram ${SOURCES} $<TARGET_OBJECTS:geogram_third_party>)
 
+ntop_import(tbb)
+target_link_libraries(geogram tbb::tbb)
 
 # Jeremie/Maxence: avoids the need to redeclare geogram include
 # path for targets that depend on geogram.
 # See: https://cmake.org/cmake/help/v3.3/command/target_include_directories.html
 # https://stackoverflow.com/questions/26243169/cmake-target-include-directories-meaning-of-scope
-target_include_directories(geogram PUBLIC ${GEOGRAM_PATH}/src/lib) 
+target_include_directories(geogram PUBLIC ${GEOGRAM_PATH}/src/lib)
 
 set_target_properties(geogram PROPERTIES
                       VERSION ${VORPALINE_VERSION}

--- a/src/lib/geogram/basic/algorithm.cpp
+++ b/src/lib/geogram/basic/algorithm.cpp
@@ -13,7 +13,7 @@
  *  * Neither the name of the ALICE Project-Team nor the names of its
  *  contributors may be used to endorse or promote products derived from this
  *  software without specific prior written permission.
- * 
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -36,9 +36,9 @@
  *     http://www.loria.fr/~levy
  *
  *     ALICE Project
- *     LORIA, INRIA Lorraine, 
+ *     LORIA, INRIA Lorraine,
  *     Campus Scientifique, BP 239
- *     54506 VANDOEUVRE LES NANCY CEDEX 
+ *     54506 VANDOEUVRE LES NANCY CEDEX
  *     FRANCE
  *
  */
@@ -49,15 +49,16 @@
 namespace GEO {
 
     bool uses_parallel_algorithm() {
-        static bool initialized = false;
-        static bool result = false;
-        if(!initialized) {
-            result =
-                CmdLine::get_arg_bool("sys:multithread") &&
-                CmdLine::get_arg_bool("algo:parallel");
-            initialized = true;
-        }
-        return result;
+        // static bool initialized = false;
+        // static bool result = false;
+        // if(!initialized) {
+        //     result =
+        //         CmdLine::get_arg_bool("sys:multithread") &&
+        //         CmdLine::get_arg_bool("algo:parallel");
+        //     initialized = true;
+        // }
+        // return result;
+        return true;
     }
 }
 

--- a/src/lib/geogram/basic/factory.cpp
+++ b/src/lib/geogram/basic/factory.cpp
@@ -13,7 +13,7 @@
  *  * Neither the name of the ALICE Project-Team nor the names of its
  *  contributors may be used to endorse or promote products derived from this
  *  software without specific prior written permission.
- * 
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -36,9 +36,9 @@
  *     http://www.loria.fr/~levy
  *
  *     ALICE Project
- *     LORIA, INRIA Lorraine, 
+ *     LORIA, INRIA Lorraine,
  *     Campus Scientifique, BP 239
- *     54506 VANDOEUVRE LES NANCY CEDEX 
+ *     54506 VANDOEUVRE LES NANCY CEDEX
  *     FRANCE
  *
  */
@@ -72,5 +72,7 @@ namespace GEO {
         auto i = r.find(name);
         return i == r.end() ? nullptr : i->second.get();
     }
+
+    std::mutex InstanceRepo::instance_mutex_;
 }
 

--- a/src/lib/geogram/basic/factory.h
+++ b/src/lib/geogram/basic/factory.h
@@ -13,7 +13,7 @@
  *  * Neither the name of the ALICE Project-Team nor the names of its
  *  contributors may be used to endorse or promote products derived from this
  *  software without specific prior written permission.
- * 
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -36,9 +36,9 @@
  *     http://www.loria.fr/~levy
  *
  *     ALICE Project
- *     LORIA, INRIA Lorraine, 
+ *     LORIA, INRIA Lorraine,
  *     Campus Scientifique, BP 239
- *     54506 VANDOEUVRE LES NANCY CEDEX 
+ *     54506 VANDOEUVRE LES NANCY CEDEX
  *     FRANCE
  *
  */
@@ -52,6 +52,7 @@
 #include <map>
 #include <vector>
 #include <typeinfo>
+#include <mutex>
 
 /**
  * \file geogram/basic/factory.h
@@ -90,6 +91,7 @@ namespace GEO {
          */
         template <class InstanceType>
         static InstanceType& instance() {
+            std::lock_guard<std::mutex> lock(instance_mutex_);
             const std::string name = typeid(InstanceType).name();
             Instance* instance = get(name);
             if(instance == nullptr) {
@@ -114,6 +116,8 @@ namespace GEO {
          * \retval a null pointer otherwise
          */
         static Instance* get(const std::string& name);
+
+        static std::mutex instance_mutex_;
     };
 
     /**************************************************************************/
@@ -169,7 +173,7 @@ namespace GEO {
 
         /**
          * \brief Finds a creator by name.
-         * \param[in] name a user-defined name identifying 
+         * \param[in] name a user-defined name identifying
          *  a creator in the Factory
          * \retval the creator associated to \p name if \p name exists
          * \retval null pointer otherwise

--- a/src/lib/geogram/basic/process_unix.cpp
+++ b/src/lib/geogram/basic/process_unix.cpp
@@ -13,7 +13,7 @@
  *  * Neither the name of the ALICE Project-Team nor the names of its
  *  contributors may be used to endorse or promote products derived from this
  *  software without specific prior written permission.
- * 
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -36,9 +36,9 @@
  *     http://www.loria.fr/~levy
  *
  *     ALICE Project
- *     LORIA, INRIA Lorraine, 
+ *     LORIA, INRIA Lorraine,
  *     Campus Scientifique, BP 239
- *     54506 VANDOEUVRE LES NANCY CEDEX 
+ *     54506 VANDOEUVRE LES NANCY CEDEX
  *     FRANCE
  *
  */
@@ -175,7 +175,7 @@ namespace {
         /** \copydoc GEO::ThreadManager::leave_critical_section() */
 	void leave_critical_section() override {
 #if defined(GEO_OS_RASPBERRY)
-            unlock_mutex_arm32(&mutex_);	    
+            unlock_mutex_arm32(&mutex_);
 #elif defined(GEO_OS_ANDROID)
             unlock_mutex_android(&mutex_);
 #else
@@ -232,7 +232,7 @@ namespace {
 
     private:
 #if defined(GEO_OS_RASPBERRY)
-        arm32_mutex_t mutex_;	
+        arm32_mutex_t mutex_;
 #elif defined(GEO_OS_ANDROID)
         android_mutex_t mutex_;
 #else
@@ -254,7 +254,7 @@ namespace {
     GEO_NORETURN_DECL void abnormal_program_termination(
         const char* message = nullptr
     ) GEO_NORETURN;
-    
+
     void abnormal_program_termination(const char* message) {
         if(message != nullptr) {
             // Do not use Logger here!
@@ -271,7 +271,7 @@ namespace {
      * \param[in] signal signal number
      */
     GEO_NORETURN_DECL void signal_handler(int signal) GEO_NORETURN;
-    
+
     void signal_handler(int signal) {
         const char* sigstr = strsignal(signal);
         std::ostringstream os;
@@ -289,7 +289,7 @@ namespace {
     GEO_NORETURN_DECL void fpe_signal_handler(
         int signal, siginfo_t* si, void* data
     ) GEO_NORETURN;
-    
+
     void fpe_signal_handler(int signal, siginfo_t* si, void* data) {
         geo_argused(signal);
         geo_argused(data);
@@ -346,7 +346,7 @@ namespace {
      * Catches uncaught C++ exceptions
      */
     GEO_NORETURN_DECL void terminate_handler() GEO_NORETURN;
-    
+
     void terminate_handler() {
         abnormal_program_termination("function terminate() was called");
     }
@@ -355,7 +355,7 @@ namespace {
      * Catches allocation errors
      */
     GEO_NORETURN_DECL void memory_exhausted_handler() GEO_NORETURN;
-    
+
     void memory_exhausted_handler() {
         abnormal_program_termination("memory exhausted");
     }
@@ -390,7 +390,7 @@ namespace GEO {
             return index_t(nb_cores);
 #elif defined GEO_OS_EMSCRIPTEN
 	    return 1;
-#else	    
+#else
             return index_t(sysconf(_SC_NPROCESSORS_ONLN));
 #endif
         }
@@ -404,7 +404,7 @@ namespace GEO {
             }
             return result;
 #else
-            // The following method seems to be more 
+            // The following method seems to be more
             // reliable than  getrusage() under Linux.
             // It works for both Linux and Android.
             size_t result = 0;
@@ -421,18 +421,18 @@ namespace GEO {
         }
 
         size_t os_max_used_memory() {
-            // The following method seems to be more 
+            // The following method seems to be more
             // reliable than  getrusage() under Linux.
             // It works for both Linux and Android.
             size_t result = 0;
             LineInput in("/proc/self/status");
-            
+
             // Some versions of Unix may not have the proc
             // filesystem (or a different organization)
             if(!in.OK()) {
                 return result;
             }
-            
+
             while(!in.eof() && in.get_line()) {
                 in.get_fields();
                 if(in.field_matches(0,"VmPeak:")) {
@@ -467,13 +467,13 @@ namespace GEO {
 #ifdef GEO_OS_EMSCRIPTEN
             geo_argused(flag);
             geo_argused(excepts);
-#else            
+#else
             if(flag) {
                 feenableexcept(excepts);
             } else {
                 fedisableexcept(excepts);
             }
-#endif            
+#endif
             return true;
 #endif
         }
@@ -502,7 +502,7 @@ namespace GEO {
             signal(SIGILL, signal_handler);
             signal(SIGBUS, signal_handler);
 
-            // Use sigaction for SIGFPE as it provides more details 
+            // Use sigaction for SIGFPE as it provides more details
             // about the error.
             struct sigaction sa, old_sa;
             sa.sa_flags = SA_SIGINFO;
@@ -542,15 +542,15 @@ namespace GEO {
             }
             return std::string("");
 #endif
-        }        
-        
+        }
+
     }
 }
 
-#else 
+#else
 
 // Declare a dummy variable so that
-// MSVC does not complain that it 
+// MSVC does not complain that it
 // generated an empty object file.
 int dummy_process_unix_compiled = 1;
 

--- a/src/lib/geogram/bibliography/bibliography.cpp
+++ b/src/lib/geogram/bibliography/bibliography.cpp
@@ -1,226 +1,226 @@
-/*
- *  Copyright (c) 2012-2014, Bruno Levy
- *  All rights reserved.
- *
- *  Redistribution and use in source and binary forms, with or without
- *  modification, are permitted provided that the following conditions are met:
- *
- *  * Redistributions of source code must retain the above copyright notice,
- *  this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *  this list of conditions and the following disclaimer in the documentation
- *  and/or other materials provided with the distribution.
- *  * Neither the name of the ALICE Project-Team nor the names of its
- *  contributors may be used to endorse or promote products derived from this
- *  software without specific prior written permission.
- * 
- *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- *  POSSIBILITY OF SUCH DAMAGE.
- *
- *  If you modify this software, you should include a notice giving the
- *  name of the person performing the modification, the date of modification,
- *  and the reason for such modification.
- *
- *  Contact: Bruno Levy
- *
- *     Bruno.Levy@inria.fr
- *     http://www.loria.fr/~levy
- *
- *     ALICE Project
- *     LORIA, INRIA Lorraine, 
- *     Campus Scientifique, BP 239
- *     54506 VANDOEUVRE LES NANCY CEDEX 
- *     FRANCE
- *
- */
+// /*
+//  *  Copyright (c) 2012-2014, Bruno Levy
+//  *  All rights reserved.
+//  *
+//  *  Redistribution and use in source and binary forms, with or without
+//  *  modification, are permitted provided that the following conditions are met:
+//  *
+//  *  * Redistributions of source code must retain the above copyright notice,
+//  *  this list of conditions and the following disclaimer.
+//  *  * Redistributions in binary form must reproduce the above copyright notice,
+//  *  this list of conditions and the following disclaimer in the documentation
+//  *  and/or other materials provided with the distribution.
+//  *  * Neither the name of the ALICE Project-Team nor the names of its
+//  *  contributors may be used to endorse or promote products derived from this
+//  *  software without specific prior written permission.
+//  *
+//  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+//  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+//  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+//  *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+//  *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+//  *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+//  *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+//  *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+//  *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+//  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+//  *  POSSIBILITY OF SUCH DAMAGE.
+//  *
+//  *  If you modify this software, you should include a notice giving the
+//  *  name of the person performing the modification, the date of modification,
+//  *  and the reason for such modification.
+//  *
+//  *  Contact: Bruno Levy
+//  *
+//  *     Bruno.Levy@inria.fr
+//  *     http://www.loria.fr/~levy
+//  *
+//  *     ALICE Project
+//  *     LORIA, INRIA Lorraine,
+//  *     Campus Scientifique, BP 239
+//  *     54506 VANDOEUVRE LES NANCY CEDEX
+//  *     FRANCE
+//  *
+//  */
 
-#include <geogram/bibliography/bibliography.h>
-#include <geogram/basic/memory.h>
-#include <geogram/basic/command_line.h>
-#include <geogram/basic/logger.h>
-#include <geogram/basic/stopwatch.h>
-#include <string>
+// #include <geogram/bibliography/bibliography.h>
+// #include <geogram/basic/memory.h>
+// #include <geogram/basic/command_line.h>
+// #include <geogram/basic/logger.h>
+// #include <geogram/basic/stopwatch.h>
+// #include <string>
 
-namespace {
-    using namespace GEO;
+// namespace {
+//     using namespace GEO;
 
-    double timeorigin;
-    
-    vector<const char*> bib_refs_;
+//     double timeorigin;
 
-    struct CitationRecord {
-	CitationRecord(
-	    const std::string& k,
-	    const std::string& f, int l,
-	    const std::string& func,
-	    const std::string& inf
-	) : key(k), file(f), line(l), function(func), info(inf) {
-	    timestamp = SystemStopwatch::now() - timeorigin;
-	}
-	std::string key;
-	std::string file;
-	int line;
-	std::string function;
-	std::string info;
-	double timestamp;
-    };
-    
-    vector<CitationRecord> citations_;
-}
+//     vector<const char*> bib_refs_;
 
-void register_embedded_bib_file(void);
+//     struct CitationRecord {
+// 	CitationRecord(
+// 	    const std::string& k,
+// 	    const std::string& f, int l,
+// 	    const std::string& func,
+// 	    const std::string& inf
+// 	) : key(k), file(f), line(l), function(func), info(inf) {
+// 	    timestamp = SystemStopwatch::now() - timeorigin;
+// 	}
+// 	std::string key;
+// 	std::string file;
+// 	int line;
+// 	std::string function;
+// 	std::string info;
+// 	double timestamp;
+//     };
 
-namespace GEO {
+//     vector<CitationRecord> citations_;
+// }
 
-    namespace Biblio {
+// void register_embedded_bib_file(void);
 
-	void initialize() {
-	    register_embedded_bib_file();
-	    timeorigin = SystemStopwatch::now();
-	    geo_cite("WEB:GEOGRAM");
-	}
+// namespace GEO {
 
-	void terminate() {
-	    if(
-		CmdLine::arg_is_declared("biblio") &&		
-		CmdLine::get_arg_bool("biblio") &&
-		citations_.size() != 0
-	    ) {
-		Logger::div("Bibliography");
-		{
-		    Logger::out("Bibliography")
-			<< "Saving references to geogram.bib"
-			<< std::endl;
-		    std::ofstream out("geogram.bib");
-		    FOR(i,bib_refs_.size()) {
-			out << bib_refs_[i];
-		    }
-		}
-		{
-		    Logger::out("Bibliography")
-			<< "Saving citations to geogram.tex"
-			<< std::endl;
-		    std::ofstream out("geogram.tex");
-		    out << "\\documentclass{article}" << std::endl;
-		    out << "\\usepackage{url}" << std::endl;
-		    out << "\\title{Geogram Bibliography Report}" << std::endl;
-		    out << "\\date{\\today}" << std::endl;
-		    out << "\\author{Geogram ver. "
-			<< Environment::instance()->get_value("version")
-			<< " citation subsystem"
-			<< "}"
-			<< std::endl;
-		    out << "\\begin{document}" << std::endl;
-		    out << "\\maketitle" << std::endl;
+//     namespace Biblio {
 
-		    if(CmdLine::get_arg_bool("biblio:command_line")) {
-			    out << "\\section*{Command Line}" << std::endl;
-			    std::vector<std::string> args;
-			    CmdLine::get_args(args);
-			    out << "\\begin{small}" << std::endl;
-			    out << "\\begin{enumerate}" << std::endl;
-			    FOR(i,args.size()) {
-				out << "\\item \\verb|"
-				    << args[i] << "| " << std::endl;
-			    }
-			    out << "\\end{enumerate}" << std::endl;
-			    out << "\\end{small}" << std::endl;
-		    }
+// 	void initialize() {
+// 	    register_embedded_bib_file();
+// 	    timeorigin = SystemStopwatch::now();
+// 	    geo_cite("WEB:GEOGRAM");
+// 	}
 
-		    out << "\\section*{Citation report}" << std::endl;
-		    
-		    out << "\\begin{enumerate}" << std::endl;
-		    FOR(i,citations_.size()) {
-			const CitationRecord& R = citations_[i];
-			std::string context =
-			    R.file + ":" +
-			    String::to_string(R.line);
-			out << "\\item "
-			    << "\\cite{" << R.key << "}: cited from: "
-			    << "\\verb|" << context << "| \\\\" << std::endl;
-			out << "\\begin{small}" << std::endl;
-			out << "\\verb|" << R.function << "|" << std::endl;
-			out << "\\end{small} \\\\" << std::endl;
-			if(R.info != "") {
-			    out << "Info: " << R.info << "\\\\" << std::endl;
-			}
-			out << "Timestamp: " << R.timestamp << std::endl;
-		    }
-		    out << "\\end{enumerate}" << std::endl;
-		    out << "\\bibliographystyle{alpha}" << std::endl;
-		    out << "\\bibliography{geogram}" << std::endl;
-		    out << "\\end{document}" << std::endl;
-		}
-	    }
-	}
-	
-	void register_references(const char* bib_refs) {
-	    bib_refs_.push_back(bib_refs);
-	}	
+// 	void terminate() {
+// 	    if(
+// 		CmdLine::arg_is_declared("biblio") &&
+// 		CmdLine::get_arg_bool("biblio") &&
+// 		citations_.size() != 0
+// 	    ) {
+// 		Logger::div("Bibliography");
+// 		{
+// 		    Logger::out("Bibliography")
+// 			<< "Saving references to geogram.bib"
+// 			<< std::endl;
+// 		    std::ofstream out("geogram.bib");
+// 		    FOR(i,bib_refs_.size()) {
+// 			out << bib_refs_[i];
+// 		    }
+// 		}
+// 		{
+// 		    Logger::out("Bibliography")
+// 			<< "Saving citations to geogram.tex"
+// 			<< std::endl;
+// 		    std::ofstream out("geogram.tex");
+// 		    out << "\\documentclass{article}" << std::endl;
+// 		    out << "\\usepackage{url}" << std::endl;
+// 		    out << "\\title{Geogram Bibliography Report}" << std::endl;
+// 		    out << "\\date{\\today}" << std::endl;
+// 		    out << "\\author{Geogram ver. "
+// 			<< Environment::instance()->get_value("version")
+// 			<< " citation subsystem"
+// 			<< "}"
+// 			<< std::endl;
+// 		    out << "\\begin{document}" << std::endl;
+// 		    out << "\\maketitle" << std::endl;
 
-	void cite(
-	    const char* ref, const char* file, int line, const char* function,
-	    const char* info
-	) {
-	    std::string shortfile = file;
-	    size_t pos = shortfile.find("src/lib/");
-	    if(pos != std::string::npos) {
-		shortfile = shortfile.substr(pos+8, shortfile.length()-pos-8);
-	    }
-	    pos = shortfile.find("OGF/");
-	    if(pos != std::string::npos) {
-		shortfile = shortfile.substr(pos, shortfile.length()-pos);
-	    }
+// 		    if(CmdLine::get_arg_bool("biblio:command_line")) {
+// 			    out << "\\section*{Command Line}" << std::endl;
+// 			    std::vector<std::string> args;
+// 			    CmdLine::get_args(args);
+// 			    out << "\\begin{small}" << std::endl;
+// 			    out << "\\begin{enumerate}" << std::endl;
+// 			    FOR(i,args.size()) {
+// 				out << "\\item \\verb|"
+// 				    << args[i] << "| " << std::endl;
+// 			    }
+// 			    out << "\\end{enumerate}" << std::endl;
+// 			    out << "\\end{small}" << std::endl;
+// 		    }
 
-	    std::string shortfunction = function;
-	    pos = shortfunction.find('(');
-	    if(pos != std::string::npos) {
-		shortfunction = shortfunction.substr(0,pos);
-		shortfunction += "()";
-	    }
+// 		    out << "\\section*{Citation report}" << std::endl;
 
-	    pos = 0;
-	    for(int i = int(shortfunction.length())-1; i>0; --i) {
-		if(shortfunction[size_t(i)] == ' ') {
-		    pos = size_t(i);
-		    break;
-		}
-	    }
-	    shortfunction = shortfunction.substr(pos, shortfunction.length()-pos);
-	    
-	    citations_.push_back(
-		CitationRecord(
-		    ref, shortfile, line, shortfunction, (info != nullptr) ? info : ""
-		)
-	    );
-	    
-	    std::string context = std::string(shortfunction) + " (" +
-		shortfile + ":" +
-		String::to_string(line) + ")" ;
-	    
-	    if(
-		CmdLine::arg_is_declared("biblio") &&
-		CmdLine::get_arg_bool("biblio")
-	    ) {
-		Logger::out("Bibliography")
-		    << "[" << ref << "] cited from: "
-		    << context << std::endl;
-	    }
-	}
+// 		    out << "\\begin{enumerate}" << std::endl;
+// 		    FOR(i,citations_.size()) {
+// 			const CitationRecord& R = citations_[i];
+// 			std::string context =
+// 			    R.file + ":" +
+// 			    String::to_string(R.line);
+// 			out << "\\item "
+// 			    << "\\cite{" << R.key << "}: cited from: "
+// 			    << "\\verb|" << context << "| \\\\" << std::endl;
+// 			out << "\\begin{small}" << std::endl;
+// 			out << "\\verb|" << R.function << "|" << std::endl;
+// 			out << "\\end{small} \\\\" << std::endl;
+// 			if(R.info != "") {
+// 			    out << "Info: " << R.info << "\\\\" << std::endl;
+// 			}
+// 			out << "Timestamp: " << R.timestamp << std::endl;
+// 		    }
+// 		    out << "\\end{enumerate}" << std::endl;
+// 		    out << "\\bibliographystyle{alpha}" << std::endl;
+// 		    out << "\\bibliography{geogram}" << std::endl;
+// 		    out << "\\end{document}" << std::endl;
+// 		}
+// 	    }
+// 	}
 
-	void reset_citations() {
-	    citations_.clear();
-	    timeorigin = SystemStopwatch::now();	    
-	}
-    }
-    
-}
+// 	void register_references(const char* bib_refs) {
+// 	    bib_refs_.push_back(bib_refs);
+// 	}
+
+// 	// void cite(
+// 	//     const char* ref, const char* file, int line, const char* function,
+// 	//     const char* info
+// 	// ) {
+// 	//     std::string shortfile = file;
+// 	//     size_t pos = shortfile.find("src/lib/");
+// 	//     if(pos != std::string::npos) {
+// 	// 	shortfile = shortfile.substr(pos+8, shortfile.length()-pos-8);
+// 	//     }
+// 	//     pos = shortfile.find("OGF/");
+// 	//     if(pos != std::string::npos) {
+// 	// 	shortfile = shortfile.substr(pos, shortfile.length()-pos);
+// 	//     }
+
+// 	//     std::string shortfunction = function;
+// 	//     pos = shortfunction.find('(');
+// 	//     if(pos != std::string::npos) {
+// 	// 	shortfunction = shortfunction.substr(0,pos);
+// 	// 	shortfunction += "()";
+// 	//     }
+
+// 	//     pos = 0;
+// 	//     for(int i = int(shortfunction.length())-1; i>0; --i) {
+// 	// 	if(shortfunction[size_t(i)] == ' ') {
+// 	// 	    pos = size_t(i);
+// 	// 	    break;
+// 	// 	}
+// 	//     }
+// 	//     shortfunction = shortfunction.substr(pos, shortfunction.length()-pos);
+
+// 	//     citations_.push_back(
+// 	// 	CitationRecord(
+// 	// 	    ref, shortfile, line, shortfunction, (info != nullptr) ? info : ""
+// 	// 	)
+// 	//     );
+
+// 	//     std::string context = std::string(shortfunction) + " (" +
+// 	// 	shortfile + ":" +
+// 	// 	String::to_string(line) + ")" ;
+
+// 	//     if(
+// 	// 	CmdLine::arg_is_declared("biblio") &&
+// 	// 	CmdLine::get_arg_bool("biblio")
+// 	//     ) {
+// 	// 	Logger::out("Bibliography")
+// 	// 	    << "[" << ref << "] cited from: "
+// 	// 	    << context << std::endl;
+// 	//     }
+// 	// }
+
+// 	void reset_citations() {
+// 	    citations_.clear();
+// 	    timeorigin = SystemStopwatch::now();
+// 	}
+//     }
+
+// }

--- a/src/lib/geogram/bibliography/bibliography.h
+++ b/src/lib/geogram/bibliography/bibliography.h
@@ -13,7 +13,7 @@
  *  * Neither the name of the ALICE Project-Team nor the names of its
  *  contributors may be used to endorse or promote products derived from this
  *  software without specific prior written permission.
- * 
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -36,9 +36,9 @@
  *     http://www.loria.fr/~levy
  *
  *     ALICE Project
- *     LORIA, INRIA Lorraine, 
+ *     LORIA, INRIA Lorraine,
  *     Campus Scientifique, BP 239
- *     54506 VANDOEUVRE LES NANCY CEDEX 
+ *     54506 VANDOEUVRE LES NANCY CEDEX
  *     FRANCE
  *
  */
@@ -50,25 +50,25 @@
 #include <geogram/basic/memory.h>
 
 namespace GEO {
-    
+
     namespace Biblio {
 
 	/**
 	 * \brief Initializes the bibliography system.
 	 */
-	void GEOGRAM_API initialize();
+	inline void GEOGRAM_API initialize() { }
 
 	/**
 	 * \brief Terminates the bibliography system.
 	 */
-	void GEOGRAM_API terminate();
-	
+	inline void GEOGRAM_API terminate() { }
+
 	/**
 	 * \brief Registers a set of bibliographic references.
 	 * \param[in] bib_refs a string with the bibliographic references,
 	 *  in Bibtex format.
 	 */
-	void GEOGRAM_API register_references(const char* bib_refs);
+	inline void GEOGRAM_API register_references(const char* bib_refs) { geo_argused(bib_refs); }
 
 	/**
 	 * \brief Cites a bibliographic reference.
@@ -82,30 +82,26 @@ namespace GEO {
 	 *  key is cited.
 	 * \param[in] info more information about the context of the citation.
 	 */
-	void GEOGRAM_API cite(
-	    const char* ref,
-	    const char* file, int line,
-	    const char* function,
-	    const char* info = nullptr
-	);
+	// void GEOGRAM_API cite(
+	//     const char* ref,
+	//     const char* file, int line,
+	//     const char* function,
+	//     const char* info = nullptr
+	// );
 
 	/**
 	 * \brief Resets all citations.
 	 */
-	void GEOGRAM_API reset_citations();
-    }
+	inline void GEOGRAM_API reset_citations() { }
+	}
 
 /**
  * \brief Cites a reference.
  * \param [in] ref a string with the bibtex key of the reference.
  */
-#ifdef GEO_COMPILER_GCC    
-#define geo_cite(ref) ::GEO::Biblio::cite(           \
-	ref, __FILE__, __LINE__, __PRETTY_FUNCTION__ \
-)
-#else
-#define geo_cite(ref) ::GEO::Biblio::cite(ref, __FILE__, __LINE__, __FUNCTION__)    
-#endif    
+#ifndef geo_cite
+#define geo_cite(x)
+#endif
 
 /**
  * \brief Cites a reference with information on the context of
@@ -113,18 +109,10 @@ namespace GEO {
  * \param [in] ref a string with the bibtex key of the reference.
  * \param [in] info more information on the context of the citation.
  */
-#ifdef GEO_COMPILER_GCC    
-#define geo_cite_with_info(ref, info) ::GEO::Biblio::cite( \
-	ref, __FILE__, __LINE__, __PRETTY_FUNCTION__, info \
-)
-#else
-#define geo_cite_with_info(ref, info) ::GEO::Biblio::cite( \
-	ref, __FILE__, __LINE__, __FUNCTION__, info        \
-)    
-#endif    
+#ifndef geo_cite_with_info
+#define geo_cite_with_info(x,y)
+#endif
 
-
-    
 }
 
 #endif

--- a/src/lib/geogram/delaunay/delaunay_2d.cpp
+++ b/src/lib/geogram/delaunay/delaunay_2d.cpp
@@ -13,7 +13,7 @@
  *  * Neither the name of the ALICE Project-Team nor the names of its
  *  contributors may be used to endorse or promote products derived from this
  *  software without specific prior written permission.
- * 
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -36,9 +36,9 @@
  *     http://www.loria.fr/~levy
  *
  *     ALICE Project
- *     LORIA, INRIA Lorraine, 
+ *     LORIA, INRIA Lorraine,
  *     Campus Scientifique, BP 239
- *     54506 VANDOEUVRE LES NANCY CEDEX 
+ *     54506 VANDOEUVRE LES NANCY CEDEX
  *     FRANCE
  *
  */
@@ -73,7 +73,7 @@ namespace {
      * \retval POSITIVE if the triangle is oriented positively
      * \retval ZERO if the triangle is flat
      * \retval NEGATIVE if the triangle is oriented negatively
-     * \todo check whether orientation is inverted as compared to 
+     * \todo check whether orientation is inverted as compared to
      *   Shewchuk's version.
      */
     inline Sign orient_2d_inexact(
@@ -82,10 +82,10 @@ namespace {
     ) {
         double a11 = p1[0] - p0[0] ;
         double a12 = p1[1] - p0[1] ;
-        
+
         double a21 = p2[0] - p0[0] ;
         double a22 = p2[1] - p0[1] ;
-        
+
         double Delta = det2x2(
             a11,a12,
             a21,a22
@@ -149,7 +149,7 @@ namespace GEO {
 	    "Analysis of the different versions of the line walk algorithm "
 	    " used by \\verb|locate()|."
 	);
-	
+
         if(dimension != 2 && dimension != 3) {
             throw InvalidDimension(dimension, "Delaunay2d", "2 or 3");
         }
@@ -192,7 +192,7 @@ namespace GEO {
                 double w = -geo_sqr(vertices[3 * i + 2]);
                 heights_[i] = -w +
                     geo_sqr(vertices[3 * i]) +
-                    geo_sqr(vertices[3 * i + 1]); 
+                    geo_sqr(vertices[3 * i + 1]);
             }
         }
 
@@ -228,7 +228,7 @@ namespace GEO {
             Logger::out("DelInternal1") << "BRIO sorting:"
                                        << sorting_time
                                        << std::endl;
-        } 
+        }
 
         // The indices of the vertices of the first tetrahedron.
         index_t v0, v1, v2;
@@ -268,16 +268,16 @@ namespace GEO {
         //   Since cell_next_ is not used at this point,
         // we reuse it for storing the conversion array that
         // maps old tet indices to new tet indices
-        // Note: tet_is_real() uses the previous value of 
+        // Note: tet_is_real() uses the previous value of
         // cell_next(), but we are processing indices
         // in increasing order and since old2new[t] is always
         // smaller or equal to t, we never overwrite a value
         // before needing it.
-        
+
         vector<index_t>& old2new = cell_next_;
         index_t nb_triangles = 0;
         index_t nb_triangles_to_delete = 0;
-        
+
         {
             for(index_t t = 0; t < max_t(); ++t) {
                 if(
@@ -320,7 +320,7 @@ namespace GEO {
         // In "keep_infinite" mode, we reorder the cells in such
         // a way that finite cells have indices [0..nb_finite_cells_-1]
         // and infinite cells have indices [nb_finite_cells_ .. nb_cells_-1]
-        
+
         if(keep_infinite_) {
             nb_finite_cells_ = 0;
             index_t finite_ptr = 0;
@@ -367,16 +367,16 @@ namespace GEO {
 
         if(benchmark_mode_) {
             if(keep_infinite_) {
-                Logger::out("DelCompress") 
-                    << "Removed " << nb_triangles_to_delete 
+                Logger::out("DelCompress")
+                    << "Removed " << nb_triangles_to_delete
                     << " triangles (free list)" << std::endl;
             } else {
-                Logger::out("DelCompress") 
-                    << "Removed " << nb_triangles_to_delete 
+                Logger::out("DelCompress")
+                    << "Removed " << nb_triangles_to_delete
                     << " triangles (free list and infinite)" << std::endl;
             }
         }
-        
+
         set_arrays(
             nb_triangles,
             cell_to_v_store_.data(), cell_to_cell_store_.data()
@@ -439,7 +439,7 @@ namespace GEO {
 
 	geo_debug_assert(!triangle_is_free(hint));
 	geo_debug_assert(!triangle_is_in_list(hint));
-	
+
         //  Always start from a real tet. If the tet is virtual,
         // find its real neighbor (always opposite to the
         // infinite vertex)
@@ -462,14 +462,14 @@ namespace GEO {
             pv[0] = vertex_ptr(finite_triangle_vertex(t,0));
             pv[1] = vertex_ptr(finite_triangle_vertex(t,1));
             pv[2] = vertex_ptr(finite_triangle_vertex(t,2));
-            
+
             for(index_t le = 0; le < 3; ++le) {
-                
+
                 signed_index_t s_t_next = triangle_adjacent(t,le);
 
                 //  If the opposite tet is -1, then it means that
                 // we are trying to locate() (e.g. called from
-                // nearest_vertex) within a tetrahedralization 
+                // nearest_vertex) within a tetrahedralization
                 // from which the infinite tets were removed.
                 if(s_t_next == -1) {
                     return NO_TRIANGLE;
@@ -483,7 +483,7 @@ namespace GEO {
                 // the next candidate (or exit the loop if they
                 // are exhausted).
                 if(t_next == t_pred) {
-                    continue ; 
+                    continue ;
                 }
 
                 //   To test the orientation of p w.r.t. the facet f of
@@ -518,11 +518,11 @@ namespace GEO {
                     goto still_walking;
                 }
             }
-        } 
+        }
 
         //   If we reach this point, we did not find a valid successor
-        // for walking (a face for which p has negative orientation), 
-        // thus we reached the tet for which p has all positive 
+        // for walking (a face for which p has negative orientation),
+        // thus we reached the tet for which p has all positive
         // face orientations (i.e. the tet that contains p).
 
         return t;
@@ -534,19 +534,19 @@ namespace GEO {
         Sign* orient
     ) const {
 
-        //   Try improving the hint by using the 
+        //   Try improving the hint by using the
         // inexact locate function. This gains
-        // (a little bit) performance (a few 
+        // (a little bit) performance (a few
         // percent in total Delaunay computation
         // time), but it is better than nothing...
-        //   Note: there is a maximum number of tets 
+        //   Note: there is a maximum number of tets
         // traversed by locate_inexact()  (2500)
         // since there exists configurations in which
         // locate_inexact() loops forever !
 
 	hint = locate_inexact(p, hint, 2500);
 
-        static Process::spinlock lock = GEOGRAM_SPINLOCK_INIT;
+        static Process::spinlock lock;
 
         // We need to have this spinlock because
         // of random() that is not thread-safe
@@ -566,7 +566,7 @@ namespace GEO {
 
 	geo_debug_assert(!triangle_is_free(hint));
 	geo_debug_assert(!triangle_is_in_list(hint));
-	
+
         //  Always start from a real tet. If the tet is virtual,
         // find its real neighbor (always opposite to the
         // infinite vertex)
@@ -582,8 +582,8 @@ namespace GEO {
 
 	geo_debug_assert(!triangle_is_free(hint));
 	geo_debug_assert(!triangle_is_in_list(hint));
-	geo_debug_assert(!triangle_is_virtual(hint));	
-	
+	geo_debug_assert(!triangle_is_virtual(hint));
+
         index_t t = hint;
         index_t t_pred = NO_TRIANGLE;
         Sign orient_local[3];
@@ -598,17 +598,17 @@ namespace GEO {
             pv[0] = vertex_ptr(finite_triangle_vertex(t,0));
             pv[1] = vertex_ptr(finite_triangle_vertex(t,1));
             pv[2] = vertex_ptr(finite_triangle_vertex(t,2));
-            
+
             // Start from a random facet
             index_t e0 = index_t(Numeric::random_int32()) % 3;
             for(index_t de = 0; de < 3; ++de) {
                 index_t le = (e0 + de) % 3;
-                
+
                 signed_index_t s_t_next = triangle_adjacent(t,le);
 
                 //  If the opposite triangle is -1, then it means that
                 // we are trying to locate() (e.g. called from
-                // nearest_vertex) within a tetrahedralization 
+                // nearest_vertex) within a tetrahedralization
                 // from which the infinite tets were removed.
                 if(s_t_next == -1) {
                     if(thread_safe) {
@@ -622,7 +622,7 @@ namespace GEO {
 		geo_debug_assert(!triangle_is_free(t_next));
 		geo_debug_assert(!triangle_is_in_list(t_next));
 
-		
+
                 //   If the candidate next tetrahedron is the
                 // one we came from, then we know already that
                 // the orientation is positive, thus we examine
@@ -630,7 +630,7 @@ namespace GEO {
                 // are exhausted).
                 if(t_next == t_pred) {
                     orient[le] = POSITIVE ;
-                    continue ; 
+                    continue ;
                 }
 
                 //   To test the orientation of p w.r.t. the facet f of
@@ -671,11 +671,11 @@ namespace GEO {
                 t = t_next;
                 goto still_walking;
             }
-        } 
+        }
 
         //   If we reach this point, we did not find a valid successor
-        // for walking (a face for which p has negative orientation), 
-        // thus we reached the tet for which p has all positive 
+        // for walking (a face for which p has negative orientation),
+        // thus we reached the tet for which p has all positive
         // face orientations (i.e. the tet that contains p).
 
         if(thread_safe) {
@@ -685,8 +685,8 @@ namespace GEO {
     }
 
     void Delaunay2d::find_conflict_zone(
-        index_t v, 
-        index_t t, const Sign* orient, 
+        index_t v,
+        index_t t, const Sign* orient,
         index_t& t_bndry, index_t& e_bndry,
         index_t& first, index_t& last
     ) {
@@ -705,18 +705,18 @@ namespace GEO {
         // the triangulation. The point already exists
         // if it's located on three faces of the
         // tetrahedron returned by locate().
-        int nb_zero = 
+        int nb_zero =
             (orient[0] == ZERO) +
             (orient[1] == ZERO) +
             (orient[2] == ZERO) ;
 
         if(nb_zero >= 2) {
-            return; 
+            return;
         }
 
         //  Weighted triangulations can have dangling
         // vertices. Such vertices p are characterized by
-        // the fact that p is not in conflict with the 
+        // the fact that p is not in conflict with the
         // tetrahedron returned by locate().
         if(weighted_ && !triangle_is_conflict(t, p)) {
             return;
@@ -735,7 +735,7 @@ namespace GEO {
         // is on some faces of the located triangle, insert
         // the neighbors accros those edges in the conflict list.
         // It saves a couple of calls to the predicates in this
-        // specific case (combinatorics are in general less 
+        // specific case (combinatorics are in general less
         // expensive than the predicates).
         if(!weighted_ && nb_zero != 0) {
             for(index_t le = 0; le < 3; ++le) {
@@ -757,7 +757,7 @@ namespace GEO {
         // Determine the conflict list by greedy propagation from t.
         find_conflict_zone_iterative(p,t,t_bndry,e_bndry,first,last);
     }
-    
+
     void Delaunay2d::find_conflict_zone_iterative(
         const double* p, index_t t_in,
         index_t& t_bndry, index_t& e_bndry,
@@ -770,7 +770,7 @@ namespace GEO {
 
             index_t t = S_.top();
             S_.pop();
-            
+
             for(index_t le = 0; le < 3; ++le) {
                 index_t t2 = index_t(triangle_adjacent(t, le));
 
@@ -786,10 +786,10 @@ namespace GEO {
                     add_triangle_to_list(t2, first, last);
                     S_.push(t2);
                     continue;
-                } 
-                
-                //   At this point, t is in conflict 
-                // and t2 is not in conflict. 
+                }
+
+                //   At this point, t is in conflict
+                // and t2 is not in conflict.
                 // We keep a reference to a tet on the boundary
                 t_bndry = t;
                 e_bndry = le;
@@ -808,18 +808,18 @@ namespace GEO {
 	index_t t_adj = index_t(triangle_adjacent(t,e));
 
 	geo_debug_assert(t_adj != index_t(-1));
-	
+
 	geo_debug_assert(triangle_is_in_list(t));
 	geo_debug_assert(!triangle_is_in_list(t_adj));
-	
+
 
 	index_t new_t_first = index_t(-1);
 	index_t new_t_prev  = index_t(-1);
-	
+
 	do {
 
 	    signed_index_t v1 = triangle_vertex(t, (e+1)%3);
-	    signed_index_t v2 = triangle_vertex(t, (e+2)%3);	    
+	    signed_index_t v2 = triangle_vertex(t, (e+2)%3);
 
 	    // Create new triangle
 	    index_t new_t = new_triangle(signed_index_t(v_in), v1, v2);
@@ -829,16 +829,16 @@ namespace GEO {
 	    set_triangle_adjacent(new_t, 0, t_adj);
 	    index_t adj_e = find_triangle_adjacent(t_adj, t);
 	    set_triangle_adjacent(t_adj, adj_e, new_t);
-	    
-	    
+
+
 	    // Move to next triangle
 	    e = (e + 1)%3;
 	    t_adj = index_t(triangle_adjacent(t,e));
 	    while(triangle_is_in_list(t_adj)) {
 		t = t_adj;
-		e = (find_triangle_vertex(t,v2) + 2)%3;		
+		e = (find_triangle_vertex(t,v2) + 2)%3;
 		t_adj = index_t(triangle_adjacent(t,e));
-		geo_debug_assert(t_adj != index_t(-1));		
+		geo_debug_assert(t_adj != index_t(-1));
 	    }
 
 	    if(new_t_prev == index_t(-1)) {
@@ -849,13 +849,13 @@ namespace GEO {
 	    }
 
 	    new_t_prev = new_t;
-	    
+
 	} while((t != t1) || (e != t1ebord));
 
 	// Connect last triangle to first triangle
 	set_triangle_adjacent(new_t_prev, 1, new_t_first);
 	set_triangle_adjacent(new_t_first, 2, new_t_prev);
-	
+
 	return new_t_prev;
     }
 
@@ -872,7 +872,7 @@ namespace GEO {
        find_conflict_zone(
            v,t,orient,t_bndry,e_bndry,first_conflict,last_conflict
        );
-       
+
        // The conflict list can be empty if:
        //  - Vertex v already exists in the triangulation
        //  - The triangulation is weighted and v is not visible
@@ -881,11 +881,11 @@ namespace GEO {
        }
 
        index_t new_triangle = stellate_conflict_zone(v,t_bndry,e_bndry);
-       
+
        // Recycle the tetrahedra of the conflict zone.
        cell_next_[last_conflict] = first_free_;
        first_free_ = first_conflict;
-       
+
        // Return one of the newly created triangles
        return new_triangle;
     }
@@ -915,7 +915,7 @@ namespace GEO {
         iv2 = iv1 + 1;
 	Sign s = ZERO;
         while(
-            iv2 < nb_vertices() &&  
+            iv2 < nb_vertices() &&
 	    (s = PCK::orient_2d(vertex_ptr(iv0), vertex_ptr(iv1), vertex_ptr(iv2))) == ZERO
 	) {
             ++iv2;
@@ -926,11 +926,11 @@ namespace GEO {
 	if(s == NEGATIVE) {
 	    std::swap(iv1,iv2);
 	}
-	    
+
         // Create the first triangle
         index_t t0 = new_triangle(
-            signed_index_t(iv0), 
-            signed_index_t(iv1), 
+            signed_index_t(iv0),
+            signed_index_t(iv1),
             signed_index_t(iv2)
         );
 

--- a/src/lib/geogram/delaunay/delaunay_3d.cpp
+++ b/src/lib/geogram/delaunay/delaunay_3d.cpp
@@ -13,7 +13,7 @@
  *  * Neither the name of the ALICE Project-Team nor the names of its
  *  contributors may be used to endorse or promote products derived from this
  *  software without specific prior written permission.
- * 
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -36,9 +36,9 @@
  *     http://www.loria.fr/~levy
  *
  *     ALICE Project
- *     LORIA, INRIA Lorraine, 
+ *     LORIA, INRIA Lorraine,
  *     Campus Scientifique, BP 239
- *     54506 VANDOEUVRE LES NANCY CEDEX 
+ *     54506 VANDOEUVRE LES NANCY CEDEX
  *     FRANCE
  *
  */
@@ -122,7 +122,7 @@ namespace GEO {
 	    "Analysis of the different versions of the line walk algorithm "
 	    " used by \\verb|locate()|."
 	);
-	
+
         if(dimension != 3 && dimension != 4) {
             throw InvalidDimension(dimension, "Delaunay3d", "3 or 4");
         }
@@ -202,7 +202,7 @@ namespace GEO {
             Logger::out("DelInternal1") << "BRIO sorting:"
                                        << sorting_time
                                        << std::endl;
-        } 
+        }
 
         // The indices of the vertices of the first tetrahedron.
         index_t v0, v1, v2, v3;
@@ -242,16 +242,16 @@ namespace GEO {
         //   Since cell_next_ is not used at this point,
         // we reuse it for storing the conversion array that
         // maps old tet indices to new tet indices
-        // Note: tet_is_real() uses the previous value of 
+        // Note: tet_is_real() uses the previous value of
         // cell_next(), but we are processing indices
         // in increasing order and since old2new[t] is always
         // smaller or equal to t, we never overwrite a value
         // before needing it.
-        
+
         vector<index_t>& old2new = cell_next_;
         index_t nb_tets = 0;
         index_t nb_tets_to_delete = 0;
-        
+
         {
             for(index_t t = 0; t < max_t(); ++t) {
                 if(
@@ -294,7 +294,7 @@ namespace GEO {
         // In "keep_infinite" mode, we reorder the cells in such
         // a way that finite cells have indices [0..nb_finite_cells_-1]
         // and infinite cells have indices [nb_finite_cells_ .. nb_cells_-1]
-        
+
         if(keep_infinite_) {
             nb_finite_cells_ = 0;
             index_t finite_ptr = 0;
@@ -341,16 +341,16 @@ namespace GEO {
 
         if(benchmark_mode_) {
             if(keep_infinite_) {
-                Logger::out("DelCompress") 
-                    << "Removed " << nb_tets_to_delete 
+                Logger::out("DelCompress")
+                    << "Removed " << nb_tets_to_delete
                     << " tets (free list)" << std::endl;
             } else {
-                Logger::out("DelCompress") 
-                    << "Removed " << nb_tets_to_delete 
+                Logger::out("DelCompress")
+                    << "Removed " << nb_tets_to_delete
                     << " tets (free list and infinite)" << std::endl;
             }
         }
-        
+
         set_arrays(
             nb_tets,
             cell_to_v_store_.data(), cell_to_cell_store_.data()
@@ -434,14 +434,14 @@ namespace GEO {
             pv[1] = vertex_ptr(finite_tet_vertex(t,1));
             pv[2] = vertex_ptr(finite_tet_vertex(t,2));
             pv[3] = vertex_ptr(finite_tet_vertex(t,3));
-            
+
             for(index_t f = 0; f < 4; ++f) {
-                
+
                 signed_index_t s_t_next = tet_adjacent(t,f);
 
                 //  If the opposite tet is -1, then it means that
                 // we are trying to locate() (e.g. called from
-                // nearest_vertex) within a tetrahedralization 
+                // nearest_vertex) within a tetrahedralization
                 // from which the infinite tets were removed.
                 if(s_t_next == -1) {
                     return NO_TETRAHEDRON;
@@ -455,7 +455,7 @@ namespace GEO {
                 // the next candidate (or exit the loop if they
                 // are exhausted).
                 if(t_next == t_pred) {
-                    continue ; 
+                    continue ;
                 }
 
                 //   To test the orientation of p w.r.t. the facet f of
@@ -490,11 +490,11 @@ namespace GEO {
                     goto still_walking;
                 }
             }
-        } 
+        }
 
         //   If we reach this point, we did not find a valid successor
-        // for walking (a face for which p has negative orientation), 
-        // thus we reached the tet for which p has all positive 
+        // for walking (a face for which p has negative orientation),
+        // thus we reached the tet for which p has all positive
         // face orientations (i.e. the tet that contains p).
 
         return t;
@@ -506,18 +506,18 @@ namespace GEO {
         Sign* orient
     ) const {
 
-        //   Try improving the hint by using the 
+        //   Try improving the hint by using the
         // inexact locate function. This gains
-        // (a little bit) performance (a few 
+        // (a little bit) performance (a few
         // percent in total Delaunay computation
         // time), but it is better than nothing...
-        //   Note: there is a maximum number of tets 
+        //   Note: there is a maximum number of tets
         // traversed by locate_inexact()  (2500)
         // since there exists configurations in which
         // locate_inexact() loops forever !
         hint = locate_inexact(p, hint, 2500);
 
-        static Process::spinlock lock = GEOGRAM_SPINLOCK_INIT;
+        static Process::spinlock lock;
 
         // We need to have this spinlock because
         // of random() that is not thread-safe
@@ -563,17 +563,17 @@ namespace GEO {
             pv[1] = vertex_ptr(finite_tet_vertex(t,1));
             pv[2] = vertex_ptr(finite_tet_vertex(t,2));
             pv[3] = vertex_ptr(finite_tet_vertex(t,3));
-            
+
             // Start from a random facet
             index_t f0 = index_t(Numeric::random_int32()) % 4;
             for(index_t df = 0; df < 4; ++df) {
                 index_t f = (f0 + df) % 4;
-                
+
                 signed_index_t s_t_next = tet_adjacent(t,f);
 
                 //  If the opposite tet is -1, then it means that
                 // we are trying to locate() (e.g. called from
-                // nearest_vertex) within a tetrahedralization 
+                // nearest_vertex) within a tetrahedralization
                 // from which the infinite tets were removed.
                 if(s_t_next == -1) {
                     if(thread_safe) {
@@ -591,7 +591,7 @@ namespace GEO {
                 // are exhausted).
                 if(t_next == t_pred) {
                     orient[f] = POSITIVE ;
-                    continue ; 
+                    continue ;
                 }
 
                 //   To test the orientation of p w.r.t. the facet f of
@@ -632,11 +632,11 @@ namespace GEO {
                 t = t_next;
                 goto still_walking;
             }
-        } 
+        }
 
         //   If we reach this point, we did not find a valid successor
-        // for walking (a face for which p has negative orientation), 
-        // thus we reached the tet for which p has all positive 
+        // for walking (a face for which p has negative orientation),
+        // thus we reached the tet for which p has all positive
         // face orientations (i.e. the tet that contains p).
 
         if(thread_safe) {
@@ -646,13 +646,13 @@ namespace GEO {
     }
 
     void Delaunay3d::find_conflict_zone(
-        index_t v, 
-        index_t t, const Sign* orient, 
+        index_t v,
+        index_t t, const Sign* orient,
         index_t& t_bndry, index_t& f_bndry,
         index_t& first, index_t& last
     ) {
-	cavity_.clear(); 
-	
+	cavity_.clear();
+
         first = last = END_OF_LIST;
 
         //  Generate a unique stamp from current vertex index,
@@ -668,19 +668,19 @@ namespace GEO {
         // the triangulation. The point already exists
         // if it's located on three faces of the
         // tetrahedron returned by locate().
-        int nb_zero = 
+        int nb_zero =
             (orient[0] == ZERO) +
             (orient[1] == ZERO) +
             (orient[2] == ZERO) +
             (orient[3] == ZERO) ;
 
         if(nb_zero >= 3) {
-            return; 
+            return;
         }
 
         //  Weighted triangulations can have dangling
         // vertices. Such vertices p are characterized by
-        // the fact that p is not in conflict with the 
+        // the fact that p is not in conflict with the
         // tetrahedron returned by locate().
         if(weighted_ && !tet_is_conflict(t, p)) {
             return;
@@ -699,7 +699,7 @@ namespace GEO {
         // is on some faces of the located tetrahedron, insert
         // the neighbors accros those faces in the conflict list.
         // It saves a couple of calls to the predicates in this
-        // specific case (combinatorics are in general less 
+        // specific case (combinatorics are in general less
         // expensive than the predicates).
         if(!weighted_ && nb_zero != 0) {
             for(index_t lf = 0; lf < 4; ++lf) {
@@ -721,7 +721,7 @@ namespace GEO {
         // Determine the conflict list by greedy propagation from t.
         find_conflict_zone_iterative(p,t,t_bndry,f_bndry,first,last);
     }
-    
+
     void Delaunay3d::find_conflict_zone_iterative(
         const double* p, index_t t_in,
         index_t& t_bndry, index_t& f_bndry,
@@ -735,7 +735,7 @@ namespace GEO {
 
             index_t t = S_.top();
             S_.pop();
-            
+
             for(index_t lf = 0; lf < 4; ++lf) {
                 index_t t2 = index_t(tet_adjacent(t, lf));
 
@@ -756,17 +756,17 @@ namespace GEO {
 		    );
                     continue;
                 }
-		
+
 
                 if(tet_is_conflict(t2, p)) {
                     // Chain t2 in conflict list
                     add_tet_to_list(t2, first, last);
                     S_.push(t2);
                     continue;
-                } 
-                
-                //   At this point, t is in conflict 
-                // and t2 is not in conflict. 
+                }
+
+                //   At this point, t is in conflict
+                // and t2 is not in conflict.
                 // We keep a reference to a tet on the boundary
                 t_bndry = t;
                 f_bndry = lf;
@@ -779,7 +779,7 @@ namespace GEO {
 		    tet_vertex(t, tet_facet_vertex(lf,1)),
 		    tet_vertex(t, tet_facet_vertex(lf,2))
 		);
-		
+
             }
         }
     }
@@ -791,32 +791,32 @@ namespace GEO {
         // inputs can cause stack overflow (system stack is limited to
         // a few megs). For instance, it can happen when a large number
         // of points are on the same sphere exactly.
-        
+
         //   To de-recursify, it uses class StellateConflictStack
         // that emulates system's stack for storing functions's
         // parameters and local variables in all the nested stack
-        // frames. 
-        
+        // frames.
+
         signed_index_t v = signed_index_t(v_in);
-        
+
         S2_.push(t1, t1fbord, t1fprev);
 
         index_t new_t;   // the newly created tetrahedron.
-        
+
         index_t t1ft2;   // traverses the 4 facets of t1.
-        
+
         index_t t2;      // the tetrahedron on the border of
                          // the conflict zone that shares an
                          // edge with t1 along t1ft2.
-        
+
         index_t t2fbord; // the facet of t2 on the border of
                          // the conflict zone.
-        
+
         index_t t2ft1;   // the facet of t2 that is incident to t1.
-        
+
     entry_point:
         S2_.get_parameters(t1, t1fbord, t1fprev);
-        
+
         geo_debug_assert(tet_is_in_list(t1));
         geo_debug_assert(tet_adjacent(t1,t1fbord)>=0);
         geo_debug_assert(!tet_is_in_list(index_t(tet_adjacent(t1,t1fbord))));
@@ -838,11 +838,11 @@ namespace GEO {
             set_tet_adjacent(new_t, t1fbord, tbord);
             set_tet_adjacent(tbord, find_tet_adjacent(tbord,t1), new_t);
         }
-            
+
         //  Lookup new_t's neighbors accros its three other
         // facets and connect them
         for(t1ft2=0; t1ft2<4; ++t1ft2) {
-            
+
             if(t1ft2 == t1fprev || tet_adjacent(new_t,t1ft2) != -1) {
                 continue;
             }
@@ -862,15 +862,15 @@ namespace GEO {
                 index_t result = new_t;
                 S2_.pop();
 
-                // Special case: we were in the outermost frame, 
+                // Special case: we were in the outermost frame,
                 // then we (truly) return from the function.
                 if(S2_.empty()) {
                     return result;
                 }
-                
+
                 S2_.get_parameters(t1, t1fbord, t1fprev);
-                S2_.get_locals(new_t, t1ft2, t2ft1); 
-                t2 = result; 
+                S2_.get_locals(new_t, t1ft2, t2ft1);
+                t2 = result;
             }
 
             set_tet_adjacent(t2, t2ft1, new_t);
@@ -883,11 +883,11 @@ namespace GEO {
         // (no need to push any return address).
         goto return_point;
     }
-                        
+
     index_t Delaunay3d::stellate_cavity(index_t v) {
-	
+
 	index_t new_tet = index_t(-1);
-	
+
 	for(index_t f=0; f<cavity_.nb_facets(); ++f) {
 	    index_t old_tet = cavity_.facet_tet(f);
 	    index_t lf = cavity_.facet_facet(f);
@@ -900,19 +900,19 @@ namespace GEO {
 	    set_tet_adjacent(t_neigh, find_tet_adjacent(t_neigh,old_tet), new_tet);
 	    cavity_.set_facet_tet(f, new_tet);
 	}
-	
+
 	for(index_t f=0; f<cavity_.nb_facets(); ++f) {
 	    new_tet = cavity_.facet_tet(f);
 	    index_t neigh1, neigh2, neigh3;
 	    cavity_.get_facet_neighbor_tets(f, neigh1, neigh2, neigh3);
 	    set_tet_adjacent(new_tet, 1, neigh1);
 	    set_tet_adjacent(new_tet, 2, neigh2);
-	    set_tet_adjacent(new_tet, 3, neigh3);		
+	    set_tet_adjacent(new_tet, 3, neigh3);
 	}
 
 	return new_tet;
     }
-    
+
     index_t Delaunay3d::insert(index_t v, index_t hint) {
        index_t t_bndry = NO_TETRAHEDRON;
        index_t f_bndry = index_t(-1);
@@ -926,7 +926,7 @@ namespace GEO {
        find_conflict_zone(
            v,t,orient,t_bndry,f_bndry,first_conflict,last_conflict
        );
-       
+
        // The conflict list can be empty if:
        //  - Vertex v already exists in the triangulation
        //  - The triangulation is weighted and v is not visible
@@ -940,11 +940,11 @@ namespace GEO {
        } else {
 	   new_tet = stellate_conflict_zone_iterative(v,t_bndry,f_bndry);
        }
-       
+
        // Recycle the tetrahedra of the conflict zone.
        cell_next_[last_conflict] = first_free_;
        first_free_ = first_conflict;
-       
+
        // Return one of the newly created tets
        return new_tet;
     }
@@ -1008,9 +1008,9 @@ namespace GEO {
 
         // Create the first tetrahedron
         index_t t0 = new_tetrahedron(
-            signed_index_t(iv0), 
-            signed_index_t(iv1), 
-            signed_index_t(iv2), 
+            signed_index_t(iv0),
+            signed_index_t(iv1),
+            signed_index_t(iv2),
             signed_index_t(iv3)
         );
 

--- a/src/lib/geogram/delaunay/periodic_delaunay_3d.cpp
+++ b/src/lib/geogram/delaunay/periodic_delaunay_3d.cpp
@@ -13,7 +13,7 @@
  *  * Neither the name of the ALICE Project-Team nor the names of its
  *  contributors may be used to endorse or promote products derived from this
  *  software without specific prior written permission.
- * 
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -36,9 +36,9 @@
  *     http://www.loria.fr/~levy
  *
  *     ALICE Project
- *     LORIA, INRIA Lorraine, 
+ *     LORIA, INRIA Lorraine,
  *     Campus Scientifique, BP 239
- *     54506 VANDOEUVRE LES NANCY CEDEX 
+ *     54506 VANDOEUVRE LES NANCY CEDEX
  *     FRANCE
  *
  */
@@ -131,7 +131,7 @@ namespace {
 	    x >>= 1;
 	}
 	return index_t(result);
-#endif	
+#endif
     }
 }
 
@@ -144,21 +144,21 @@ namespace GEO {
     class PeriodicDelaunay3dThread : public GEO::Thread, public Periodic {
     public:
 	friend class PeriodicDelaunay3d;
-	
+
         /**
          * \brief Symbolic value for cell_thread_[t] that
          *  indicates that no thread owns t.
          */
         static const index_t NO_THREAD = thread_index_t(-1);
 
-        /** 
+        /**
          * \brief Creates a new PeriodicDelaunay3dThread.
          * \details Each PeriodicDelaunay3dThread has an affected working
          *  zone, i.e. a range of tetrahedra indices in which the
-         *  thread is allowed to create tetrahedra. 
+         *  thread is allowed to create tetrahedra.
          * \param[in] master a pointer to the PeriodicDelaunay3d
          *  this thread belongs to
-         * \param[in] pool_begin first tetrahedron index of 
+         * \param[in] pool_begin first tetrahedron index of
          *  the working zone of this PeriodicDelaunay3dThread
          * \param[in] pool_end one position past the last tetrahedron
          *  index of the working zone of this PeriodicDelaunay3dThread
@@ -167,7 +167,7 @@ namespace GEO {
             PeriodicDelaunay3d* master,
             index_t pool_begin,
             index_t pool_end
-        ) : 
+        ) :
             master_(master),
 	    periodic_(master->periodic_),
 	    period_(master->period_),
@@ -201,14 +201,14 @@ namespace GEO {
 
             b_hint_ = NO_TETRAHEDRON;
             e_hint_ = NO_TETRAHEDRON;
-	    
+
 	    set_pool(pool_begin, pool_end);
-	   
+
         }
 
 	/**
 	 * \brief Initializes the pool of tetrahedra for this thread.
-         * \param[in] pool_begin first tetrahedron index of 
+         * \param[in] pool_begin first tetrahedron index of
          *  the working zone of this PeriodicDelaunay3dThread
          * \param[in] pool_end one position past the last tetrahedron
          *  index of the working zone of this PeriodicDelaunay3dThread
@@ -242,7 +242,7 @@ namespace GEO {
             max_used_t_ = std::max(max_used_t, index_t(1));
 	}
 
-	
+
         /**
          * \brief PeriodicDelaunay3dThread destructor.
          */
@@ -259,7 +259,7 @@ namespace GEO {
 	bool has_empty_cells() {
 	    return has_empty_cells_;
 	}
-	
+
         /**
          * \brief Copies some variables from another thread.
          * \param[in] rhs the thread from which variables should
@@ -293,7 +293,7 @@ namespace GEO {
          * \brief Gets the number of failed locate() calls.
          * \return the number of failed locate() calls
          * \details locate() can fail when it cannot acquire
-         *  the tetrahedra that are traversed, due to 
+         *  the tetrahedra that are traversed, due to
          *  interferences from another thread.
          */
         index_t nb_failed_locate() const {
@@ -307,23 +307,23 @@ namespace GEO {
 	index_t nb_traversed_tets() const {
 	    return nb_traversed_tets_;
 	}
-	
+
         /**
          * \brief Sets the point index sequence that
          *  should be processed by this thread.
          * \param[in] b index of the first point to insert
-         * \param[in] e one position past the index of the 
+         * \param[in] e one position past the index of the
          *   last point to insert
          */
         void set_work(index_t b, index_t e) {
             work_begin_ = signed_index_t(b);
             // e is one position past the last point index
-            // to insert. 
+            // to insert.
             work_end_ = signed_index_t(e)-1;
         }
 
         /**
-         * \brief Gets the number of remaining points to 
+         * \brief Gets the number of remaining points to
          *  be inserted.
          * \return the number of points to be inserted by
          *  this thread
@@ -361,10 +361,10 @@ namespace GEO {
         }
 
         /**
-         * \brief Inserts the point sequence allocated to 
+         * \brief Inserts the point sequence allocated to
          *  this thread.
          * \details The point sequence was previously defined
-         *  by set_work(). 
+         *  by set_work().
          */
         virtual void run() {
 	    has_empty_cells_ = false;
@@ -385,14 +385,14 @@ namespace GEO {
             // If true, insert in b->e order,
             // else insert in e->b order
             direction_ = true;
-            
+
             while(
 		work_end_ >= work_begin_ &&
 		!memory_overflow_ &&
 		!has_empty_cells_ &&
 		!master_->has_empty_cells_
 	    ) {
-                index_t v = direction_ ? 
+                index_t v = direction_ ?
                     index_t(work_begin_) : index_t(work_end_) ;
                 index_t& hint = direction_ ? b_hint_ : e_hint_;
 
@@ -424,7 +424,7 @@ namespace GEO {
                             wait_for_event(interfering_thread_);
                         } else {
                             // If this thread has a lower priority than
-                            // the interfering thread, try inserting 
+                            // the interfering thread, try inserting
                             // from the other end of the points sequence.
                             direction_ = !direction_;
                         }
@@ -436,7 +436,7 @@ namespace GEO {
 	    if(has_empty_cells_) {
 		master_->has_empty_cells_ = true;
 	    }
-	    
+
 	    //   Fix by Hiep Vu: wake up threads that potentially missed
 	    // the previous wake ups.
 	    pthread_mutex_lock(&mutex_);
@@ -459,7 +459,7 @@ namespace GEO {
          *  facet on the convex hull of the points.
          */
         static const signed_index_t VERTEX_AT_INFINITY = -1;
-        
+
 
          /**
          * \brief Maximum valid index for a tetrahedron.
@@ -483,13 +483,13 @@ namespace GEO {
          * \retval false otherwise
          */
         bool tet_is_finite(index_t t) const {
-            return 
+            return
                 cell_to_v_store_[4 * t]     >= 0 &&
                 cell_to_v_store_[4 * t + 1] >= 0 &&
                 cell_to_v_store_[4 * t + 2] >= 0 &&
                 cell_to_v_store_[4 * t + 3] >= 0;
         }
-        
+
         /**
          * \brief Tests whether a tetrahedron is
          *  a real one.
@@ -521,9 +521,9 @@ namespace GEO {
 		finite_tet_vertex(t,0) < nb_vertices_non_periodic_ ||
 		finite_tet_vertex(t,1) < nb_vertices_non_periodic_ ||
 		finite_tet_vertex(t,2) < nb_vertices_non_periodic_ ||
-		finite_tet_vertex(t,3) < nb_vertices_non_periodic_ ) ;					 
+		finite_tet_vertex(t,3) < nb_vertices_non_periodic_ ) ;
         }
-	
+
         /**
          * \brief Tests whether a tetrahedron is
          *  in the free list.
@@ -537,7 +537,7 @@ namespace GEO {
         bool tet_is_free(index_t t) const {
             return tet_is_in_list(t);
         }
-        
+
         /**
          * \brief Tests whether a tetrahedron is contained
          *  by a given linked list.
@@ -550,7 +550,7 @@ namespace GEO {
          */
         bool tet_is_in_list(index_t t, index_t first) const {
             for(
-                index_t cur = first; cur != END_OF_LIST; 
+                index_t cur = first; cur != END_OF_LIST;
                 cur = tet_next(cur)
             ) {
                 if(cur == t) {
@@ -576,7 +576,7 @@ namespace GEO {
             }
 
             iv0 = 0;
-            
+
             iv1 = 1;
             while(
                 iv1 < nb_vertices_non_periodic_ &&
@@ -590,7 +590,7 @@ namespace GEO {
             if(iv1 == nb_vertices()) {
                 return NO_TETRAHEDRON;
             }
-            
+
             iv2 = iv1 + 1;
             while(
                 iv2 < nb_vertices_non_periodic_ &&
@@ -625,16 +625,16 @@ namespace GEO {
             }
 
             geo_debug_assert(s != ZERO);
-            
+
             if(s == NEGATIVE) {
                 std::swap(iv2, iv3);
             }
 
             // Create the first tetrahedron
             index_t t0 = new_tetrahedron(
-                signed_index_t(iv0), 
-                signed_index_t(iv1), 
-                signed_index_t(iv2), 
+                signed_index_t(iv0),
+                signed_index_t(iv1),
+                signed_index_t(iv2),
                 signed_index_t(iv3)
             );
 
@@ -678,10 +678,10 @@ namespace GEO {
 
 
 	 /**
-	  * \brief Creates a star of tetrahedra filling the conflict 
+	  * \brief Creates a star of tetrahedra filling the conflict
 	  *  zone.
           * \param[in] v the index of the point to be inserted
-	  * \details This function is used when the Cavity computed 
+	  * \details This function is used when the Cavity computed
 	  *  when traversing the conflict zone is OK, that is to say
 	  *  when its array sizes were not exceeded.
           * \return the index of one the newly created tetrahedron
@@ -701,20 +701,20 @@ namespace GEO {
 		set_tet_adjacent(t_neigh, find_tet_adjacent(t_neigh,old_tet), new_tet);
 		cavity_.set_facet_tet(f, new_tet);
 	    }
-	
+
 	    for(index_t f=0; f<cavity_.nb_facets(); ++f) {
 		new_tet = cavity_.facet_tet(f);
 		index_t neigh1, neigh2, neigh3;
 		cavity_.get_facet_neighbor_tets(f, neigh1, neigh2, neigh3);
 		set_tet_adjacent(new_tet, 1, neigh1);
 		set_tet_adjacent(new_tet, 2, neigh2);
-		set_tet_adjacent(new_tet, 3, neigh3);		
+		set_tet_adjacent(new_tet, 3, neigh3);
 	    }
-	    
+
 	    return new_tet;
 	}
 
-	
+
         /**
          * \brief Inserts a point in the triangulation.
          * \param[in] v the index of the point to be inserted
@@ -739,7 +739,7 @@ namespace GEO {
             }
 
 	    vec3 p = vertex(v);
-	    
+
             Sign orient[4];
             index_t t = locate(v,p,hint,orient);
 
@@ -758,7 +758,7 @@ namespace GEO {
             // the triangulation. The point already exists
             // if it's located on three faces of the
             // tetrahedron returned by locate().
-            int nb_zero = 
+            int nb_zero =
                 (orient[0] == ZERO) +
                 (orient[1] == ZERO) +
                 (orient[2] == ZERO) +
@@ -777,7 +777,7 @@ namespace GEO {
 	    vec4 p_lifted = lifted_vertex(v,p);
 
 	    cavity_.clear();
-	    
+
             bool ok = find_conflict_zone(v,p_lifted,t,t_bndry,f_bndry);
 
             // When in multithreading mode, we cannot allocate memory
@@ -812,12 +812,12 @@ namespace GEO {
 
 
             geo_debug_assert(
-                nb_acquired_tets_ == 
+                nb_acquired_tets_ ==
                 tets_to_delete_.size() + tets_to_release_.size()
             );
 
 #ifdef GEO_DEBUG
-            // Sanity check: make sure this threads owns all the tets 
+            // Sanity check: make sure this threads owns all the tets
             // in conflict and their neighbors.
             for(index_t i=0; i<tets_to_delete_.size(); ++i) {
                 index_t tdel = tets_to_delete_[i];
@@ -842,11 +842,11 @@ namespace GEO {
 
             index_t new_tet = index_t(-1);
 	    if(cavity_.OK()) {
-		new_tet = stellate_cavity(v);	
+		new_tet = stellate_cavity(v);
 	    } else {
 		new_tet = stellate_conflict_zone_iterative(v,t_bndry,f_bndry);
 	    }
-       
+
             // Recycle the tetrahedra of the conflict zone.
             for(index_t i=0; i<tets_to_delete_.size()-1; ++i) {
                 cell_next_[tets_to_delete_[i]] = tets_to_delete_[i+1];
@@ -869,7 +869,7 @@ namespace GEO {
                 set_tet_vertex(tdel,2,-2);
                 set_tet_vertex(tdel,3,-2);
             }
-       
+
             // Return one of the newly created tets
             hint=new_tet;
             release_tets();
@@ -887,8 +887,8 @@ namespace GEO {
          *  boundary of the conflict zone
          * \param[out] f_bndry the facet along which t_bndry is
          *  adjacent to the boundary of the conflict zone
-         *  The other tetrahedra are linked, and can be traversed 
-         *  from \p first by using tet_next() until \p last or END_OF_LIST 
+         *  The other tetrahedra are linked, and can be traversed
+         *  from \p first by using tet_next() until \p last or END_OF_LIST
          *  is reached.
          *  The conflict zone can be empty under two circumstances:
          *  - the vertex \p v already exists in the triangulation
@@ -899,7 +899,7 @@ namespace GEO {
          * \retval false otherwise
          */
         bool find_conflict_zone(
-            index_t v, const vec4& p, index_t t, 
+            index_t v, const vec4& p, index_t t,
             index_t& t_bndry, index_t& f_bndry
         ) {
             nb_tets_to_create_ = 0;
@@ -912,7 +912,7 @@ namespace GEO {
 
             //  Weighted triangulations can have dangling
             // vertices. Such vertices p are characterized by
-            // the fact that p is not in conflict with the 
+            // the fact that p is not in conflict with the
             // tetrahedron returned by locate().
             if(!tet_is_in_conflict(t,v,p)) {
                 release_tet(t);
@@ -948,7 +948,7 @@ namespace GEO {
 	  * \param[in] v_in the index of the point to be inserted
           * \param[in] p_in the point to be inserted
           * \param[in] t_in index of a tetrahedron in the conflict zone
-          * \pre The tetrahedron \p t was alredy marked as 
+          * \pre The tetrahedron \p t was alredy marked as
           *  conflict (tet_is_in_list(t))
           */
         bool find_conflict_zone_iterative(
@@ -968,18 +968,18 @@ namespace GEO {
                 for(index_t lf = 0; lf < 4; ++lf) {
 		    index_t v2=v;
 		    vec4 p2=p;
-		    
+
                     index_t t2 = index_t(tet_adjacent(t, lf));
-                
+
                     // If t2 is already owned by current thread, then
                     // its status was previously determined.
                     if(owns_tet(t2)) {
 
                         geo_debug_assert(
-                            tet_is_marked_as_conflict(t2) == 
+                            tet_is_marked_as_conflict(t2) ==
                             tet_is_in_conflict(t2,v2,p2)
                         );
-                    
+
                         // If t2 is not in conflict list, then t has a facet
                         // on the border of the conflict zone, and there is
                         // a tet to create.
@@ -999,7 +999,7 @@ namespace GEO {
                         S_.resize(0);
                         return false;
                     }
-                
+
                     geo_debug_assert(owns_tet(t2));
 
                     if(!tet_is_in_conflict(t2,v2,p2)) {
@@ -1015,8 +1015,8 @@ namespace GEO {
                         continue;
                     }
 
-                    //  At this point, t is in conflict 
-                    // and t2 is not in conflict. 
+                    //  At this point, t is in conflict
+                    // and t2 is not in conflict.
                     // We keep a reference to a tet on the boundary
                     t_boundary_ = t;
                     f_boundary_ = lf;
@@ -1054,12 +1054,12 @@ namespace GEO {
 	    return (weights_ == nullptr) ? 0.0 : weights_[i];
         }
 
-	
+
 	/**
 	 * \brief gets a vertex.
 	 * \param[in] v the index of the vertex, in 0..nb_vertices_-1
 	 * \param[out] result a pointer to the 3d coordinates of the vertex.
-	 * \details In periodic mode, does vertex translation (v is a 
+	 * \details In periodic mode, does vertex translation (v is a
 	 *  virtual vertex index).
 	 */
 	void get_vertex(index_t v, double* result) const {
@@ -1078,11 +1078,11 @@ namespace GEO {
 	    result[1] += double(translation[instance][1]) * period_;
 	    result[2] += double(translation[instance][2]) * period_;
 	}
-	
+
 	/**
 	 * \brief gets a vertex.
 	 * \param[in] v the index of the vertex, in 0..nb_vertices_-1
-	 * \details In periodic mode, does vertex translation (v is a 
+	 * \details In periodic mode, does vertex translation (v is a
 	 *  virtual vertex index).
 	 * \return the 3d vertex.
 	 */
@@ -1095,9 +1095,9 @@ namespace GEO {
 	/**
 	 * \brief gets a lifted vertex.
 	 * \param[in] v the index of the vertex, in 0..nb_vertices_-1
-	 * \param[out] result the 4d coordinates of the vertex, 
+	 * \param[out] result the 4d coordinates of the vertex,
 	 *  shifted on the paraboloid and shifted by the weight.
-	 * \details In periodic mode, does vertex translation (v is a 
+	 * \details In periodic mode, does vertex translation (v is a
 	 *  virtual vertex index).
 	 */
 	void get_lifted_vertex(index_t v, double* result) const {
@@ -1118,11 +1118,11 @@ namespace GEO {
 	    result[3] +=
 		geo_sqr(result[0]) + geo_sqr(result[1]) + geo_sqr(result[2]);
 	}
-	
+
 	/**
 	 * \brief gets a lifted vertex.
 	 * \param[in] v the index of the vertex, in 0..nb_vertices_-1
-	 * \details In periodic mode, does vertex translation (v is a 
+	 * \details In periodic mode, does vertex translation (v is a
 	 *  virtual vertex index).
 	 * \return the 4d vertex, lifted on the paraboloid, and shifted by
 	 *  the weight.
@@ -1137,7 +1137,7 @@ namespace GEO {
 	 * \brief gets a lifted vertex.
 	 * \param[in] v the index of the vertex, in 0..nb_vertices_-1
 	 * \param[in] p the geometric location of vertex v
-	 * \details In periodic mode, does vertex translation (v is a 
+	 * \details In periodic mode, does vertex translation (v is a
 	 *  virtual vertex index).
 	 * \return the 4d vertex, lifted on the paraboloid, and shifted by
 	 *  the weight.
@@ -1148,7 +1148,7 @@ namespace GEO {
 		geo_sqr(p.x) + geo_sqr(p.y) + geo_sqr(p.z) - non_periodic_weight(periodic_vertex_real(v))
 	    );
 	}
-	
+
 	/**
 	 * \brief Orientation predicate with indices.
 	 * \param i , j , k , l the four indices of the four vertices.
@@ -1176,7 +1176,7 @@ namespace GEO {
 		const double* pi = non_periodic_vertex_ptr(i);
 		const double* pj = non_periodic_vertex_ptr(j);
 		const double* pk = non_periodic_vertex_ptr(k);
-		const double* pl = non_periodic_vertex_ptr(l);		
+		const double* pl = non_periodic_vertex_ptr(l);
 		double hi = geo_sqr(pi[0]) + geo_sqr(pi[1]) + geo_sqr(pi[2]) - non_periodic_weight(i);
 		double hj = geo_sqr(pj[0]) + geo_sqr(pj[1]) + geo_sqr(pj[2]) - non_periodic_weight(j);
 		double hk = geo_sqr(pk[0]) + geo_sqr(pk[1]) + geo_sqr(pk[2]) - non_periodic_weight(k);
@@ -1186,7 +1186,7 @@ namespace GEO {
 		    hi, hj, hk, hl
 		);
 	    }
-	    
+
 	    double V[4][4];
 	    get_lifted_vertex(i,V[0]);
 	    get_lifted_vertex(j,V[1]);
@@ -1210,13 +1210,13 @@ namespace GEO {
 		const double* pi = non_periodic_vertex_ptr(i);
 		const double* pj = non_periodic_vertex_ptr(j);
 		const double* pk = non_periodic_vertex_ptr(k);
-		const double* pl = non_periodic_vertex_ptr(l);		
+		const double* pl = non_periodic_vertex_ptr(l);
 		const double* pm = non_periodic_vertex_ptr(m);
 		double hi = geo_sqr(pi[0]) + geo_sqr(pi[1]) + geo_sqr(pi[2]) - non_periodic_weight(i);
 		double hj = geo_sqr(pj[0]) + geo_sqr(pj[1]) + geo_sqr(pj[2]) - non_periodic_weight(j);
 		double hk = geo_sqr(pk[0]) + geo_sqr(pk[1]) + geo_sqr(pk[2]) - non_periodic_weight(k);
 		double hl = geo_sqr(pl[0]) + geo_sqr(pl[1]) + geo_sqr(pl[2]) - non_periodic_weight(l);
-		double hm = geo_sqr(pm[0]) + geo_sqr(pm[1]) + geo_sqr(pm[2]) - non_periodic_weight(m);		
+		double hm = geo_sqr(pm[0]) + geo_sqr(pm[1]) + geo_sqr(pm[2]) - non_periodic_weight(m);
 		return PCK::orient_3dlifted_SOS(
 		    pi, pj, pk, pl, pm,
 		    hi, hj, hk, hl, hm
@@ -1224,7 +1224,7 @@ namespace GEO {
 	    }
 
 	    // Periodic mode.
-	    double V[5][4];	    
+	    double V[5][4];
 	    get_lifted_vertex(i,V[0]);
 	    get_lifted_vertex(j,V[1]);
 	    get_lifted_vertex(k,V[2]);
@@ -1235,7 +1235,7 @@ namespace GEO {
 		V[0][3], V[1][3], V[2][3], V[3][3], V[4][3]
 	    );
 	}
-	
+
         /**
          * \brief Tests whether a given tetrahedron is in conflict with
          *  a given 3d point.
@@ -1253,7 +1253,7 @@ namespace GEO {
         bool tet_is_in_conflict(index_t t, index_t v, const vec4& p) const {
 
 	    geo_argused(p);
-	    
+
             // Lookup tetrahedron vertices
 
 	    index_t iv[4];
@@ -1261,7 +1261,7 @@ namespace GEO {
                 iv[i] = index_t(tet_vertex(t,i));
 	    }
 
-	    
+
             // Check for virtual tetrahedra (then in_sphere()
             // is replaced with orient3d())
             for(index_t lf = 0; lf < 4; ++lf) {
@@ -1297,14 +1297,14 @@ namespace GEO {
                     if(owns_tet(t2)) {
                         return tet_is_marked_as_conflict(t2);
                     }
-                    
+
                     //  If t2 was not already visited, then we need to
                     // switch to the in_circum_circle_3d() predicate.
 
                     index_t iq0 = iv[(lf+1)%4];
                     index_t iq1 = iv[(lf+2)%4];
                     index_t iq2 = iv[(lf+3)%4];
-                    
+
 		    return (in_circle_3dlifted_SOS(iq0, iq1, iq2, v) > 0);
                 }
             }
@@ -1315,11 +1315,11 @@ namespace GEO {
 
 	    return (orient_3dlifted_SOS(iv[0], iv[1], iv[2], iv[3], v) > 0);
         }
-        
+
 
         /**
          * \brief Finds the tetrahedron that contains a point.
-         * \details The tetrahedron is acquired by this thread. If the 
+         * \details The tetrahedron is acquired by this thread. If the
          *  tetrahedron could not be acquired, then NO_TETRAHEDRON is returned.
          *  If the point is on a face, edge or vertex,
          *  the function returns one of the tetrahedra incident
@@ -1333,8 +1333,8 @@ namespace GEO {
          *  If the point is outside the convex hull of
          *  the inserted so-far points, then the returned tetrahedron
          *  is a virtual one (first vertex is the "vertex at infinity"
-         *  of index -1) 
-         * \retval NO_TETRAHEDRON if the tetrahedron could not be 
+         *  of index -1)
+         * \retval NO_TETRAHEDRON if the tetrahedron could not be
          *  acquired by this thread, or if the virtual tetrahedra
          *  were previously removed
          */
@@ -1366,7 +1366,7 @@ namespace GEO {
                      hint = thread_safe_random_(max_used_t_);
                  }
                  if(
-                     tet_is_free(hint) || 
+                     tet_is_free(hint) ||
                      (!owns_tet(hint) && !acquire_tet(hint))
                  ) {
                      if(owns_tet(hint)) {
@@ -1378,7 +1378,7 @@ namespace GEO {
                          if(tet_vertex(hint,f) == VERTEX_AT_INFINITY) {
                              index_t new_hint = index_t(tet_adjacent(hint,f));
                              if(
-                                 tet_is_free(new_hint) || 
+                                 tet_is_free(new_hint) ||
                                  !acquire_tet(new_hint)
                              ) {
                                  new_hint = NO_TETRAHEDRON;
@@ -1429,20 +1429,20 @@ namespace GEO {
                  index_t f0 = thread_safe_random_4_();
                  for(index_t df = 0; df < 4; ++df) {
                      index_t f = (f0 + df) % 4;
-                     
+
                      signed_index_t s_t_next = tet_adjacent(t,f);
-                     
+
                      //  If the opposite tet is -1, then it means that
                      // we are trying to locate() (e.g. called from
-                     // nearest_vertex) within a tetrahedralization 
+                     // nearest_vertex) within a tetrahedralization
                      // from which the infinite tets were removed.
                      if(s_t_next == -1) {
                          release_tet(t);
                          return NO_TETRAHEDRON;
                      }
-                     
+
                      index_t t_next = index_t(s_t_next);
-                     
+
                      //   If the candidate next tetrahedron is the
                      // one we came from, then we know already that
                      // the orientation is positive, thus we examine
@@ -1450,7 +1450,7 @@ namespace GEO {
                      // are exhausted).
                      if(t_next == t_pred) {
                          orient[f] = POSITIVE ;
-                         continue ; 
+                         continue ;
                      }
 
                      //   To test the orientation of p w.r.t. the facet f of
@@ -1463,7 +1463,7 @@ namespace GEO {
                      orient[f] = PCK::orient_3d(
 			 pv[0].data(), pv[1].data(), pv[2].data(), pv[3].data()
 		     );
-                     
+
                      //   If the orientation is not negative, then we cannot
                      // walk towards t_next, and examine the next candidate
                      // (or exit the loop if they are exhausted).
@@ -1489,18 +1489,18 @@ namespace GEO {
                      }
 
 		     ++nb_traversed_tets_;
-		     
+
                      //   If we reach this point, then t_next is a valid
                      // successor, thus we are still walking.
                      t_pred = t;
                      t = t_next;
                      goto still_walking;
                  }
-             } 
+             }
 
              //   If we reach this point, we did not find a valid successor
-             // for walking (a face for which p has negative orientation), 
-             // thus we reached the tet for which p has all positive 
+             // for walking (a face for which p has negative orientation),
+             // thus we reached the tet for which p has all positive
              // face orientations (i.e. the tet that contains p).
 
 #ifdef GEO_DEBUG
@@ -1523,10 +1523,10 @@ namespace GEO {
 
              return t;
          }
-        
+
 
     protected:
-        
+
         /**
          * \brief Tests whether a tetrahedron was marked as conflict.
          * \pre owns_tet(t)
@@ -1542,7 +1542,7 @@ namespace GEO {
 
         /**
          * \brief Gets the number of tetrahedra in conflict.
-         * \return the number of tetrahedra in conflict, 
+         * \return the number of tetrahedra in conflict,
          *  specified by mark_tet_as_conflict()
          */
         index_t nb_tets_in_conflict() const {
@@ -1551,7 +1551,7 @@ namespace GEO {
 
         /**
          * \brief Marks a tetrahedron as conflict.
-         * \details The index of the tetrahedron is also 
+         * \details The index of the tetrahedron is also
          *  stored it in the list of conflict tetrahedra.
          * \param[in] t index of the tetrahedron to mark
          * \pre owns_tet(t)
@@ -1566,7 +1566,7 @@ namespace GEO {
 
         /**
          * \brief Marks a tetrahedron as neighbor of the conflict zone.
-         * \details The index of the tetrahedron is also 
+         * \details The index of the tetrahedron is also
          *  stored it in the list of tetrahedra to release.
          * \param[in] t index of the tetrahedron to mark
          * \pre owns_tet(t)
@@ -1584,14 +1584,14 @@ namespace GEO {
          */
         void acquire_and_mark_tet_as_created(index_t t) {
             //  The tet was created in this thread's tet pool,
-            // therefore there is no need to use sync 
+            // therefore there is no need to use sync
             // primitives to acquire a lock on it.
             geo_debug_assert(cell_thread_[t] == NO_THREAD);
             cell_thread_[t] = thread_index_t(id() << 1);
 #ifdef GEO_DEBUG
             ++nb_acquired_tets_;
 #endif
-            tets_to_release_.push_back(t);            
+            tets_to_release_.push_back(t);
         }
 
 
@@ -1632,13 +1632,13 @@ namespace GEO {
                     (char)(id() << 1),
                     (char)(NO_THREAD)
                 ));
-#else            
-            interfering_thread_ = 
+#else
+            interfering_thread_ =
                 __sync_val_compare_and_swap(
                     &cell_thread_[t], NO_THREAD, thread_index_t(id() << 1)
                 );
 #endif
-            
+
             if(interfering_thread_ == NO_THREAD) {
                 geo_debug_assert(t == first_free_ || !tet_is_in_list(t));
 #ifdef GEO_DEBUG
@@ -1692,9 +1692,9 @@ namespace GEO {
                 cell_to_v_store_[4 * t + 3] == VERTEX_AT_INFINITY) ;
         }
 
-        
+
         /**
-         * \brief Returns the local index of a vertex by 
+         * \brief Returns the local index of a vertex by
          *   facet and by local vertex index in the facet.
          * \details
          * tet facet vertex is such that the tetrahedron
@@ -1707,7 +1707,7 @@ namespace GEO {
          * any vertex lv.
          * \param[in] f local facet index, in (0,1,2,3)
          * \param[in] v local vertex index, in (0,1,2)
-         * \return the local tetrahedron vertex index of 
+         * \return the local tetrahedron vertex index of
          *  vertex \p v in facet \p f
          */
         static index_t tet_facet_vertex(index_t f, index_t v) {
@@ -1799,9 +1799,9 @@ namespace GEO {
             geo_debug_assert(owns_tet(t2));
             cell_to_cell_store_[4 * t1 + lf1] = signed_index_t(t2);
         }
-        
+
         /**
-         * \brief Finds the index of the facet across which t1 is 
+         * \brief Finds the index of the facet across which t1 is
          *  adjacent to t2_in.
          * \param[in] t1 first tetrahedron
          * \param[in] t2_in second tetrahedron
@@ -1852,7 +1852,7 @@ namespace GEO {
             geo_debug_assert(lv1 != lv2);
             return index_t(halfedge_facet_[lv1][lv2]);
         }
-        
+
 
         /**
          *  Gets the local facet indices incident to an
@@ -1860,9 +1860,9 @@ namespace GEO {
          * \param[in] t index of the tetrahedron
          * \param[in] v1 global index of the first extremity
          * \param[in] v2 global index of the second extremity
-         * \param[out] f12 the local index of the facet 
+         * \param[out] f12 the local index of the facet
          *  indicent to the halfedge [v1,v2]
-         * \param[out] f21 the local index of the facet 
+         * \param[out] f21 the local index of the facet
          *  indicent to the halfedge [v2,v1]
          */
         void get_facets_by_halfedge(
@@ -1871,7 +1871,7 @@ namespace GEO {
         ) const {
             geo_debug_assert(t < max_t());
             geo_debug_assert(v1 != v2);
-        
+
             //   Find local index of v1 and v2 in tetrahedron t
             // The following expression is 10% faster than using
             // if() statements (multiply by boolean result of test).
@@ -1884,7 +1884,7 @@ namespace GEO {
 	    lv2 = (T[1] == v2) | ((T[2] == v2) * 2) | ((T[3] == v2) * 3);
 	    geo_debug_assert(lv1 != 0 || T[0] == v1);
 	    geo_debug_assert(lv2 != 0 || T[0] == v2);
-            
+
             geo_debug_assert(lv1 >= 0);
             geo_debug_assert(lv2 >= 0);
             geo_debug_assert(lv1 != lv2);
@@ -1921,7 +1921,7 @@ namespace GEO {
          * \details Tetrahedra can be linked, it is used to manage
          *  both the free list that recycles deleted tetrahedra,
          *  the conflict region and the list of newly created
-         *  tetrahedra. 
+         *  tetrahedra.
          * \param[in] t the index of the tetrahedron
          * \retval true if tetrahedron \p t belongs to a linked list
          * \retval false otherwise
@@ -2011,7 +2011,7 @@ namespace GEO {
 		) {
 		    master_->nb_reallocations_++;
 		}
-		
+
                 master_->cell_to_v_store_.resize(
                     master_->cell_to_v_store_.size() + 4, -1
                 );
@@ -2058,7 +2058,7 @@ namespace GEO {
          * \return the index of the newly created tetrahedron
          */
         index_t new_tetrahedron(
-            signed_index_t v1, signed_index_t v2, 
+            signed_index_t v1, signed_index_t v2,
             signed_index_t v3, signed_index_t v4
         ) {
             index_t result = new_tetrahedron();
@@ -2079,9 +2079,9 @@ namespace GEO {
          */
         static index_t find_4(const signed_index_t* T, signed_index_t v) {
             // The following expression is 10% faster than using
-            // if() statements. This uses the C++ norm, that 
-            // ensures that the 'true' boolean value converted to 
-            // an int is always 1. With most compilers, this avoids 
+            // if() statements. This uses the C++ norm, that
+            // ensures that the 'true' boolean value converted to
+            // an int is always 1. With most compilers, this avoids
             // generating branching instructions.
             // Thank to Laurent Alonso for this idea.
             // Note: Laurent also has this version:
@@ -2094,7 +2094,7 @@ namespace GEO {
             // Sanity check, important if it was T[0], not explicitly
             // tested (detects input that does not meet the precondition).
             geo_debug_assert(T[result] == v);
-            return result; 
+            return result;
         }
 
 
@@ -2112,11 +2112,11 @@ namespace GEO {
 	     geo_debug_assert(periodic_vertex_instance(v) == 0);
 
 	     geo_debug_assert(T[0] != -1 && T[1] != -1 && T[2] != -1 && T[3] != -1);
-	     
+
             // The following expression is 10% faster than using
-            // if() statements. This uses the C++ norm, that 
-            // ensures that the 'true' boolean value converted to 
-            // an int is always 1. With most compilers, this avoids 
+            // if() statements. This uses the C++ norm, that
+            // ensures that the 'true' boolean value converted to
+            // an int is always 1. With most compilers, this avoids
             // generating branching instructions.
             // Thank to Laurent Alonso for this idea.
             // Note: Laurent also has this version:
@@ -2128,14 +2128,14 @@ namespace GEO {
 		((periodic_vertex_real(index_t(T[2])) == v) * 2) |
 		((periodic_vertex_real(index_t(T[3])) == v) * 3)
 	    );
-    
+
             // Sanity check, important if it was T[0], not explicitly
             // tested (detects input that does not meet the precondition).
 	    geo_debug_assert(periodic_vertex_real(index_t(T[result])) == v);
-            return result; 
+            return result;
         }
 
-	
+
         /**
          * \brief Wakes up all the threads that are waiting for
          *  this thread.
@@ -2143,7 +2143,7 @@ namespace GEO {
         void send_event() {
             pthread_cond_broadcast(&cond_);
         }
-        
+
         /**
          * \brief Waits for a thread.
          * \details Sleeps until thread \p t calls send_event().
@@ -2154,14 +2154,14 @@ namespace GEO {
 	    // Fixed by Hiep Vu: enlarged critical section (contains
 	    // now the test (!thrd->finished)
             PeriodicDelaunay3dThread* thrd = thread(t);
-	    pthread_mutex_lock(&(thrd->mutex_));	    
+	    pthread_mutex_lock(&(thrd->mutex_));
             if(!thrd->finished_) {
                 pthread_cond_wait(&(thrd->cond_), &(thrd->mutex_));
             }
-	    pthread_mutex_unlock(&(thrd->mutex_));	    
+	    pthread_mutex_unlock(&(thrd->mutex_));
         }
 
-        /****** iterative stellate_conflict_zone *****************/        
+        /****** iterative stellate_conflict_zone *****************/
 
         /**
          * \brief Used to represent the stack in the
@@ -2235,7 +2235,7 @@ namespace GEO {
                 t1ft2 = index_t(top().t1ft2);
                 t2ft1 = index_t(top().t2ft1);
             }
-            
+
             /**
              * \brief Pops a stack frame.
              */
@@ -2243,7 +2243,7 @@ namespace GEO {
                 geo_debug_assert(!empty());
                 store_.pop_back();
             }
-            
+
             /**
              * \brief Tests whether the stack is empty.
              * \retval true if the stack is empty
@@ -2252,7 +2252,7 @@ namespace GEO {
             bool empty() const {
                 return store_.empty();
             }
-            
+
         private:
 
             /**
@@ -2262,9 +2262,9 @@ namespace GEO {
             struct Frame {
                 // Parameters
                 index_t t1;
-                index_t new_t;                
+                index_t new_t;
                 Numeric::uint8 t1fbord ;
-                
+
                 // Local variables
                 Numeric::uint8 t1fprev ;
                 Numeric::uint8 t1ft2   ;
@@ -2292,7 +2292,7 @@ namespace GEO {
                 geo_debug_assert(!empty());
                 return *store_.rbegin();
             }
-            
+
             std::vector<Frame> store_;
         };
 
@@ -2301,7 +2301,7 @@ namespace GEO {
          *  zone.
          * \details For each tetrahedron facet on the border of the
          *  conflict zone, a new tetrahedron is created, resting on
-         *  the facet and incident to vertex \p v. The function is 
+         *  the facet and incident to vertex \p v. The function is
          *  called recursively until the entire conflict zone is filled.
          * \param[in] v_in the index of the point to be inserted
          * \param[in] t1 index of a tetrahedron on the border
@@ -2321,29 +2321,29 @@ namespace GEO {
             // inputs can cause stack overflow (system stack is limited to
             // a few megs). For instance, it can happen when a large number
             // of points are on the same sphere exactly.
-            
+
             //   To de-recursify, it uses class StellateConflictStack
             // that emulates system's stack for storing functions's
             // parameters and local variables in all the nested stack
-            // frames. 
-        
+            // frames.
+
             signed_index_t v = signed_index_t(v_in);
-            
+
             S2_.push(t1, t1fbord, t1fprev);
-            
+
             index_t new_t;   // the newly created tetrahedron.
-            
+
             index_t t1ft2;   // traverses the 4 facets of t1.
-            
+
             index_t t2;      // the tetrahedron on the border of
                              // the conflict zone that shares an
                              // edge with t1 along t1ft2.
-            
+
             index_t t2fbord; // the facet of t2 on the border of
                              // the conflict zone.
-        
+
             index_t t2ft1;   // the facet of t2 that is incident to t1.
-        
+
         entry_point:
             S2_.get_parameters(t1, t1fbord, t1fprev);
 
@@ -2370,24 +2370,24 @@ namespace GEO {
 	    // We generate the tetrahedron with the three vertices of the tet outside
 	    // the conflict zone and the newly created vertex in the local frame of the
 	    // tet outside the conflict zone.
-	    
-	    // Replace in new_t the vertex opposite to t1fbord with v		
-	    set_tet_vertex(new_t, t1fbord, v);		
+
+	    // Replace in new_t the vertex opposite to t1fbord with v
+	    set_tet_vertex(new_t, t1fbord, v);
 
             {
-		// Connect new_t with t1's neighbor across t1fbord		
+		// Connect new_t with t1's neighbor across t1fbord
                 set_tet_adjacent(new_t, t1fbord, tbord);
                 set_tet_adjacent(tbord, find_tet_adjacent(tbord,t1), new_t);
             }
-            
+
             //  Lookup new_t's neighbors across its three other
             // facets and connect them
             for(t1ft2=0; t1ft2<4; ++t1ft2) {
-                
+
                 if(t1ft2 == t1fprev || tet_adjacent(new_t,t1ft2) != -1) {
                     continue;
                 }
-                
+
                 // Get t1's neighbor along the border of the conflict zone
                 if(!get_neighbor_along_conflict_zone_border(
                        t1,t1fbord,t1ft2, t2,t2fbord,t2ft1
@@ -2402,18 +2402,18 @@ namespace GEO {
                     // This is the return value of the called function.
                     index_t result = new_t;
                     S2_.pop();
-                    
-                    // Special case: we were in the outermost frame, 
+
+                    // Special case: we were in the outermost frame,
                     // then we (truly) return from the function.
                     if(S2_.empty()) {
                         return result;
                     }
-                    
+
                     S2_.get_parameters(t1, t1fbord, t1fprev);
-                    S2_.get_locals(new_t, t1ft2, t2ft1); 
-                    t2 = result; 
+                    S2_.get_locals(new_t, t1ft2, t2ft1);
+                    t2 = result;
                 }
-                
+
                 set_tet_adjacent(t2, t2ft1, new_t);
                 set_tet_adjacent(new_t, t1ft2, t2);
             }
@@ -2426,16 +2426,16 @@ namespace GEO {
         }
 
         /**
-         * \brief Finds the neighbor of a tetrahedron on the border of the 
+         * \brief Finds the neighbor of a tetrahedron on the border of the
          *  conflict zone.
          * \details This function is used by stellate_conflict_zone_iterative()
          * \param[in] t1 a tetrahedron on the border of the conflict zone
          * \param[in] t1fborder the local facet index of \p t1 along which it
          *  is on the border of the conflict zone
-         * \param[in] t1ft2 the local facet index of \p t1 that will be 
+         * \param[in] t1ft2 the local facet index of \p t1 that will be
          *  traversed
          * \param[out] t2 a tetrahedron on the border of the conflict zone,
-         *  with an edge common to facets \p t1fborder and \p t1ft2 of 
+         *  with an edge common to facets \p t1fborder and \p t1ft2 of
          *  tetrahedron \p t1
          * \param[out] t2fborder the local facet index of \p t2 along which it
          *  is on the border of the conflict zone
@@ -2453,24 +2453,24 @@ namespace GEO {
             index_t& t2fborder,
             index_t& t2ft1
         ) const {
-            
+
             // Note: this function is a bit long for an inline function,
             // but I observed a (modest) performance gain doing so.
-            
+
             //   Find two vertices that are both on facets new_f and f1
             //  (the edge around which we are turning)
             //  This uses duality as follows:
-            //  Primal form (not used here): 
+            //  Primal form (not used here):
             //    halfedge_facet_[v1][v2] returns a facet that is incident
             //    to both v1 and v2.
             //  Dual form (used here):
-            //    halfedge_facet_[f1][f2] returns a vertex that both 
+            //    halfedge_facet_[f1][f2] returns a vertex that both
             //    f1 and f2 are incident to.
-            signed_index_t ev1 = 
+            signed_index_t ev1 =
                 tet_vertex(t1, index_t(halfedge_facet_[t1ft2][t1fborder]));
-            signed_index_t ev2 = 
+            signed_index_t ev2 =
                 tet_vertex(t1, index_t(halfedge_facet_[t1fborder][t1ft2]));
-            
+
             //   Turn around edge [ev1,ev2] inside the conflict zone
             // until we reach again the boundary of the conflict zone.
             // Traversing inside the conflict zone is faster (as compared
@@ -2478,13 +2478,13 @@ namespace GEO {
             index_t cur_t = t1;
             index_t cur_f = t1ft2;
             index_t next_t = index_t(tet_adjacent(cur_t,cur_f));
-            while(tet_is_marked_as_conflict(next_t)) {            
+            while(tet_is_marked_as_conflict(next_t)) {
                 geo_debug_assert(next_t != t1);
                 cur_t = next_t;
                 cur_f = get_facet_by_halfedge(cur_t,ev1,ev2);
                 next_t = index_t(tet_adjacent(cur_t, cur_f));
             }
-             
+
             //  At this point, cur_t is in conflict zone and
             // next_t is outside the conflict zone.
             index_t f12,f21;
@@ -2493,7 +2493,7 @@ namespace GEO {
             signed_index_t v_neigh_opposite = tet_vertex(next_t,f12);
             t2ft1 = find_tet_vertex(t2, v_neigh_opposite);
             t2fborder = cur_f;
-            
+
             //  Test whether the found neighboring tet was created
             //  (then return true) or is an old tet in conflict
             //  (then return false).
@@ -2505,7 +2505,7 @@ namespace GEO {
          *   stellate_conflict_zone_iterative() function.
          */
         StellateConflictStack S2_;
-        
+
         /*************************** debugging ************************/
 
         /**
@@ -2523,7 +2523,7 @@ namespace GEO {
             std::cerr << ' ';
         }
 
-        
+
         /**
          * \brief For debugging purposes, displays a tetrahedron.
          * \param[in] t index of the tetrahedron to display.
@@ -2546,7 +2546,7 @@ namespace GEO {
             show_tet_adjacent(t, 2);
             show_tet_adjacent(t, 3);
             std::cerr << "] ";
-            
+
             for(index_t f = 0; f < 4; ++f) {
                 std::cerr << 'f' << f << ':';
                 for(index_t v = 0; v < 3; ++v) {
@@ -2599,7 +2599,7 @@ namespace GEO {
                             }
                             if(!found) {
                                 std::cerr
-                                    << lf 
+                                    << lf
                                     << ":Adjacent link is not bidirectional"
                                     << std::endl;
                                 ok = false;
@@ -2666,7 +2666,7 @@ namespace GEO {
                                 std::cerr << "Tet " << t <<
                                     " is in conflict with vertex " << v
                                           << std::endl;
-                                
+
                                 std::cerr << "  offending tet: ";
                                 show_tet(t);
                             }
@@ -2694,7 +2694,7 @@ namespace GEO {
         vector<signed_index_t>& cell_to_cell_store_;
         vector<index_t>& cell_next_;
         vector<thread_index_t>& cell_thread_;
-        
+
         index_t first_free_;
         index_t nb_free_;
         bool memory_overflow_;
@@ -2702,10 +2702,10 @@ namespace GEO {
         index_t v1_,v2_,v3_,v4_; // The first four vertices
 
 	struct SFrame {
-	    
+
 	    SFrame() {
 	    }
-	    
+
 	    SFrame(
 		index_t t_in,
 		index_t v_in,
@@ -2715,7 +2715,7 @@ namespace GEO {
 		v(v_in),
 		p(p_in) {
 	    }
-	    
+
 	    SFrame(
 		const SFrame& rhs
 	    ):
@@ -2730,15 +2730,15 @@ namespace GEO {
 		p = rhs.p;
 		return *this;
 	    }
-	    
+
 	    index_t t;
 	    index_t v;
 	    vec4 p;
 	};
-	
+
         vector<SFrame> S_;
         index_t nb_tets_to_create_;
-        index_t t_boundary_; // index of a tet,facet on the bndry 
+        index_t t_boundary_; // index of a tet,facet on the bndry
         index_t f_boundary_; // of the conflict zone.
 
         bool direction_;
@@ -2769,7 +2769,7 @@ namespace GEO {
 	vector<std::pair<index_t,index_t> > border_tet_2_periodic_vertex_;
 
 	bool has_empty_cells_;
-	
+
         /**
          * \brief Gives the indexing of tetrahedron facet
          *  vertices.
@@ -2793,7 +2793,7 @@ namespace GEO {
 	 */
 	Cavity cavity_;
 
-	/** 
+	/**
 	 * \brief Statistics for locate()
 	 */
 	index_t nb_traversed_tets_;
@@ -2826,8 +2826,8 @@ namespace GEO {
 
     /*************************************************************************/
 
-    
-    
+
+
     PeriodicDelaunay3d::PeriodicDelaunay3d(
 	bool periodic, double period
     ) :
@@ -2875,7 +2875,7 @@ namespace GEO {
 	    "Analysis of the different versions of the line walk algorithm "
 	    " used by \\verb|locate()|."
 	);
-	
+
         debug_mode_ = CmdLine::get_arg_bool("dbg:delaunay");
         verbose_debug_mode_ = CmdLine::get_arg_bool("dbg:delaunay_verbose");
         debug_mode_ = (debug_mode_ || verbose_debug_mode_);
@@ -2883,7 +2883,7 @@ namespace GEO {
 	nb_vertices_non_periodic_ = 0;
     }
 
-    
+
     void PeriodicDelaunay3d::set_vertices(
         index_t nb_vertices, const double* vertices
     ) {
@@ -2897,17 +2897,17 @@ namespace GEO {
 	    if(expected_max_index > Numeric::uint64(INT32_MAX)) {
 		Logger::err("OTM") << "indices will overflow" << std::endl;
 		Logger::err("OTM")
-		    << "recompile with -DGARGANTUA " 
+		    << "recompile with -DGARGANTUA "
 		    << "to activate 64bit indices" << std::endl;
 		exit(0);
 	    }
 	}
 	#endif
 
-	if(periodic_) { 
+	if(periodic_) {
 	    PCK::set_SOS_mode(PCK::SOS_LEXICO);
 	}
-	
+
         Stopwatch* W = nullptr ;
         if(benchmark_mode_) {
             W = new Stopwatch("SpatialSort");
@@ -2922,7 +2922,7 @@ namespace GEO {
 		3, dimension(),
                 64, 0.125,
                 &levels_
-            );        
+            );
         } else {
             reorder_.resize(nb_vertices);
             for(index_t i = 0; i < nb_vertices; ++i) {
@@ -2935,24 +2935,24 @@ namespace GEO {
     }
 
     void PeriodicDelaunay3d::set_weights(const double* weights) {
-	weights_ = weights;	
+	weights_ = weights;
     }
-    
+
     void PeriodicDelaunay3d::compute() {
-	
+
 	has_empty_cells_ = false;
-	
+
 	if(periodic_) {
 	    reorder_.resize(nb_vertices_non_periodic_);
 	}
-	
+
         Stopwatch* W = nullptr ;
         if(benchmark_mode_) {
             W = new Stopwatch("DelInternal");
         }
 
         index_t expected_tetra = nb_vertices() * 7;
-    
+
         // Allocate the tetrahedra
         cell_to_v_store_.assign(expected_tetra * 4,-1);
         cell_to_cell_store_.assign(expected_tetra * 4,-1);
@@ -2966,7 +2966,7 @@ namespace GEO {
         index_t pool_begin = 0;
         threads_.clear();
         for(index_t t=0; t<nb_threads; ++t) {
-            index_t pool_end = 
+            index_t pool_end =
                 (t == nb_threads - 1) ? expected_tetra : pool_begin + pool_size;
             threads_.push_back(
                 new PeriodicDelaunay3dThread(this, pool_begin, pool_end)
@@ -2975,7 +2975,7 @@ namespace GEO {
         }
 
 
-        // Create first tetrahedron and triangulate first set of points 
+        // Create first tetrahedron and triangulate first set of points
         // in sequential mode.
 
 
@@ -2983,12 +2983,12 @@ namespace GEO {
         while(lvl < (levels_.size() - 1) && levels_[lvl] < 1000) {
             ++lvl;
         }
-	
+
         if(benchmark_mode_) {
             Logger::out("PDEL")
                 << "Using " << levels_.size()-1 << " levels" << std::endl;
-            Logger::out("PDEL") 
-                << "Levels 0 - " << lvl-1 
+            Logger::out("PDEL")
+                << "Levels 0 - " << lvl-1
                 << ": bootstraping with first levels in sequential mode"
                 << std::endl;
         }
@@ -3001,14 +3001,14 @@ namespace GEO {
 	    has_empty_cells_ = true;
 	    return;
 	}
-	
+
         index_t first_lvl = lvl;
 
         // Insert points in all BRIO levels
         for(; lvl<levels_.size()-1; ++lvl) {
 
             if(benchmark_mode_) {
-                Logger::out("PDEL") << "Level " 
+                Logger::out("PDEL") << "Level "
                                     << lvl << " : start" << std::endl;
             }
 
@@ -3020,7 +3020,7 @@ namespace GEO {
             index_t b = lvl_b;
             for(index_t t=0; t<threads_.size(); ++t) {
                 index_t e = t == threads_.size()-1 ? lvl_e : b+work_size;
-                
+
                 // Copy the indices of the first created tetrahedron
                 // and the maximum valid tetrahedron index max_t_
                 if(lvl == first_lvl && t!=0) {
@@ -3044,8 +3044,8 @@ namespace GEO {
             index_t tot_rollbacks = 0 ;
             index_t tot_failed_locate = 0 ;
             for(index_t t=0; t<threads_.size(); ++t) {
-                Logger::out("PDEL") 
-                    << "thread " << t << " : " 
+                Logger::out("PDEL")
+                    << "thread " << t << " : "
                     << thread(t)->nb_rollbacks() << " rollbacks  "
                     << thread(t)->nb_failed_locate() << " failed locate"
                     << std::endl;
@@ -3053,7 +3053,7 @@ namespace GEO {
                 tot_failed_locate += thread(t)->nb_failed_locate();
             }
             Logger::out("PDEL") << "------------------" << std::endl;
-            Logger::out("PDEL") << "total: " 
+            Logger::out("PDEL") << "total: "
                                 << tot_rollbacks << " rollbacks  "
                                 << tot_failed_locate << " failed locate"
                                 << std::endl;
@@ -3068,7 +3068,7 @@ namespace GEO {
             PeriodicDelaunay3dThread* t1 = thread(t);
             nb_sequential_points += t1->work_size();
             if(t != 0) {
-                // We need to copy max_t_ from previous thread, 
+                // We need to copy max_t_ from previous thread,
                 // since the memory pool may have grown.
                 PeriodicDelaunay3dThread* t2 = thread(t-1);
                 t1->initialize_from(t2);
@@ -3081,7 +3081,7 @@ namespace GEO {
         // the threads in increasing number, so we copy it from the
         // last thread into thread0 since we use thread0 afterwards
         // to do the "compaction" afterwards.
-        
+
         if(nb_sequential_points != 0) {
             PeriodicDelaunay3dThread* t0 = thread(0);
 	    PeriodicDelaunay3dThread* tn = thread(
@@ -3089,7 +3089,7 @@ namespace GEO {
 	    );
             t0->initialize_from(tn);
         }
-        
+
 	if(periodic_) {
 	    handle_periodic_boundaries();
 	}
@@ -3097,7 +3097,7 @@ namespace GEO {
 	if(has_empty_cells_) {
 	    return;
 	}
-	
+
         if(benchmark_mode_) {
             if(nb_sequential_points != 0) {
                 Logger::out("PDEL") << "Local thread memory overflow occurred:"
@@ -3106,7 +3106,7 @@ namespace GEO {
                                     << " points inserted in sequential mode"
                                     << std::endl;
             } else {
-                Logger::out("PDEL") 
+                Logger::out("PDEL")
                     << "All the points were inserted in parallel mode"
                     << std::endl;
             }
@@ -3114,7 +3114,7 @@ namespace GEO {
 
         if(benchmark_mode_) {
             Logger::out("DelInternal2") << "Core insertion algo:"
-                                       << W->elapsed_time() 
+                                       << W->elapsed_time()
                                        << std::endl;
         }
         delete W;
@@ -3125,7 +3125,7 @@ namespace GEO {
                     static_cast<PeriodicDelaunay3dThread*>(threads_[i].get())
                     ->max_t() << std::endl;
             }
-            
+
             thread0->check_combinatorics(verbose_debug_mode_);
             thread0->check_geometry(verbose_debug_mode_);
         }
@@ -3139,18 +3139,18 @@ namespace GEO {
         );
 
 	// We need v_to_cell even if CICL is not
-	// stored. 
+	// stored.
 	if(!stores_cicl()) {
 	    update_v_to_cell();
 	}
-	
+
 	if(periodic_) {
-#ifdef GEO_DEBUG	    
+#ifdef GEO_DEBUG
 	    FOR(v, nb_vertices_non_periodic_) {
 		index_t t = index_t(v_to_cell_[v]);
 		geo_assert(t == index_t(-1) || t < nb_tets);
 	    }
-#endif	    
+#endif
 	}
     }
 
@@ -3160,7 +3160,7 @@ namespace GEO {
         //   Since cell_next_ is not used at this point,
         // we reuse it for storing the conversion array that
         // maps old tet indices to new tet indices
-        // Note: tet_is_real() uses the previous value of 
+        // Note: tet_is_real() uses the previous value of
         // cell_next(), but we are processing indices
         // in increasing order and since old2new[t] is always
         // smaller or equal to t, we never overwrite a value
@@ -3203,7 +3203,7 @@ namespace GEO {
 		cell_to_v_store_.resize(4 * nb_tets);
 		cell_to_cell_store_.resize(4 * nb_tets);
 	    }
-	    
+
             for(index_t i = 0; i < 4 * nb_tets; ++i) {
                 signed_index_t t = cell_to_cell_store_[i];
                 geo_debug_assert(t >= 0);
@@ -3220,7 +3220,7 @@ namespace GEO {
         // In "keep_infinite" mode, we reorder the cells in such
         // a way that finite cells have indices [0..nb_finite_cells_-1]
         // and infinite cells have indices [nb_finite_cells_ .. nb_cells_-1]
-        
+
         if(keep_infinite_) {
             nb_finite_cells_ = 0;
             index_t finite_ptr = 0;
@@ -3264,23 +3264,23 @@ namespace GEO {
                 cell_to_cell_store_[i] = t;
             }
         }
-        
-        
+
+
         if(benchmark_mode_) {
-	    Logger::out("DelCompress") 
+	    Logger::out("DelCompress")
 		<< "max tets " << thread0->max_t()
 		<< std::endl;
-	    
-	    Logger::out("DelCompress") 
+
+	    Logger::out("DelCompress")
 		<< "Final number of tets " << nb_tets
 		<< std::endl;
             if(keep_infinite_) {
-                Logger::out("DelCompress") 
-                    << "Removed " << nb_tets_to_delete 
+                Logger::out("DelCompress")
+                    << "Removed " << nb_tets_to_delete
                     << " tets (free list)" << std::endl;
             } else {
-                Logger::out("DelCompress") 
-                    << "Removed " << nb_tets_to_delete 
+                Logger::out("DelCompress")
+                    << "Removed " << nb_tets_to_delete
                     << " tets (free list and infinite)" << std::endl;
             }
         }
@@ -3301,7 +3301,7 @@ namespace GEO {
 	}
 	return nb_tets;
     }
-    
+
     index_t PeriodicDelaunay3d::nearest_vertex(const double* p) const {
         // TODO
         return Delaunay::nearest_vertex(p);
@@ -3330,7 +3330,7 @@ namespace GEO {
 	    }
 	    periodic_v_to_cell_data_.assign(cur, index_t(-1));
 	}
-	
+
 	if(keeps_infinite()) {
 	    geo_assert(!periodic_);
 	    v_to_cell_.assign(nb_vertices()+1, -1);
@@ -3344,7 +3344,7 @@ namespace GEO {
 		}
 	    }
 	} else {
-	    v_to_cell_.assign(nb_vertices(), -1);	    
+	    v_to_cell_.assign(nb_vertices(), -1);
 	    for(index_t c = 0; c < nb_cells(); c++) {
 		for(index_t lv = 0; lv < 4; lv++) {
 		    index_t v = index_t(cell_vertex(c, lv));
@@ -3358,7 +3358,7 @@ namespace GEO {
 			index_t v_instance = periodic_vertex_instance(v);
 
 			geo_debug_assert((vertex_instances_[v_real] & (1u << v_instance))!=0);
-			
+
 			index_t slot = pop_count(
 			       vertex_instances_[v_real] & ((1u << v_instance)-1)
 			) - 1;
@@ -3366,7 +3366,7 @@ namespace GEO {
 			periodic_v_to_cell_data_[
 			    periodic_v_to_cell_rowptr_[v_real] + slot
 			] = c;
-			
+
 			// periodic_v_to_cell_[v] = c;
 		    }
 		}
@@ -3393,7 +3393,7 @@ namespace GEO {
 		set_next_around_vertex(index_t(t), lv, index_t(t));
 	    }
 	}
-	
+
 	if(keeps_infinite()) {
 
 	    {
@@ -3418,8 +3418,8 @@ namespace GEO {
 		    }
 		}
 	    }
-	    
-	    
+
+
 	} else {
 	    for(index_t t = 0; t < nb_cells(); ++t) {
 		for(index_t lv = 0; lv < 4; ++lv) {
@@ -3437,7 +3437,7 @@ namespace GEO {
 		}
 	    }
 	}
-	
+
         is_locked_ = false;
     }
 
@@ -3455,7 +3455,7 @@ namespace GEO {
 	} else {
 	    index_t v_real = periodic_vertex_real(v);
 	    index_t v_instance = periodic_vertex_instance(v);
-	    
+
 	    geo_debug_assert((vertex_instances_[v_real] & (1u << v_instance))!=0);
 
 	    index_t slot = pop_count(
@@ -3466,7 +3466,7 @@ namespace GEO {
 		periodic_v_to_cell_rowptr_[v_real] + slot
 	    ];
 	}
-	
+
 	// Can happen: empty power cell.
 	if(t == index_t(-1)) {
 	    return;
@@ -3504,7 +3504,7 @@ namespace GEO {
 	return
 	    geo_sqr(p[0]-q[0]) +
 	    geo_sqr(p[1]-q[1]) +
-	    geo_sqr(p[2]-q[2]) ; 
+	    geo_sqr(p[2]-q[2]) ;
     }
 
     /**
@@ -3522,10 +3522,10 @@ namespace GEO {
 	// Create global vertex indices if not present.
 	C.create_vglobal();
 	C.clear();
-	
+
 	// Create the vertex at infinity.
 	C.create_vertex(vec4(0.0, 0.0, 0.0, 0.0), index_t(-1));
-	
+
 	GEO::vec3 Pi = vertex(i);
 	double wi = weight(i);
 	double Pi_len2 = Pi[0]*Pi[0] + Pi[1]*Pi[1] + Pi[2]*Pi[2];
@@ -3555,7 +3555,7 @@ namespace GEO {
 	}
     }
 
-    
+
     GEO::index_t PeriodicDelaunay3d::copy_Laguerre_cell_facet_from_Delaunay(
 	GEO::index_t i,
 	const GEO::vec3& Pi,
@@ -3566,7 +3566,7 @@ namespace GEO {
 	IncidentTetrahedra& W
     ) const {
 	geo_argused(W);
-	
+
 	// Local tet vertex indices from facet
 	// and vertex in facet indices.
 	static GEO::index_t fv[4][3] = {
@@ -3575,18 +3575,18 @@ namespace GEO {
 	    {3,1,0},
 	    {0,1,2}
 	};
-	
+
 	GEO::index_t f = index(t,GEO::signed_index_t(i));
 	GEO::index_t jkl[3];  // Global index (in Delaunay) of triangle vertices
 	VBW::index_t l_jkl[3];// Local index (in C) of triangle vertices
 
-	
+
 	// Find or create the three vertices of the facet.
 	for(int lfv=0; lfv<3; ++lfv) {
 
 	    jkl[lfv] = GEO::index_t(cell_vertex(t, fv[f][lfv]));
 	    l_jkl[lfv] = VBW::index_t(-1);
-	    
+
 	    // Vertex already created in C (note:
 	    // also works for vertex at infinity)
 	    for(VBW::index_t u=0; u<C.nb_v(); ++u) {
@@ -3622,33 +3622,33 @@ namespace GEO {
 
     void PeriodicDelaunay3d::insert_vertices(index_t b, index_t e) {
 	nb_vertices_ = reorder_.size();
-	
+
 	PeriodicDelaunay3dThread* thread0 = thread(0);
 
 	Hilbert_sort_periodic(
 	    // total nb of possible periodic vertices
-	    nb_vertices_non_periodic_ * 27, 
+	    nb_vertices_non_periodic_ * 27,
 	    vertex_ptr(0),
 	    reorder_,
-	    3, dimension(), 
+	    3, dimension(),
 	    reorder_.begin() + long(b),
 	    reorder_.begin() + long(e),
 	    period_
 	);
-	
+
 	if(benchmark_mode_) {
 	    Logger::out("Periodic") << "Inserting "	<< (e-b)
 				    << " additional vertices" << std::endl;
 	}
 
-#ifdef GEO_DEBUG	    
+#ifdef GEO_DEBUG
 	for(index_t i=b; i+1<e; ++i) {
 	    geo_debug_assert(reorder_[i] != reorder_[i+1]);
 	}
 #endif
-	
+
 	nb_reallocations_ = 0;
-		
+
 	index_t expected_tetra = reorder_.size() * 7;
 	cell_to_v_store_.reserve(expected_tetra * 4);
 	cell_to_cell_store_.reserve(expected_tetra * 4);
@@ -3676,7 +3676,7 @@ namespace GEO {
 		<< double(total_nb_traversed_tets) / double(e-b)
 		<< " avg. traversed tet per insertion." << std::endl;
 	}
-	
+
 	set_arrays(
 	    thread0->max_t(),
 	    cell_to_v_store_.data(),
@@ -3691,7 +3691,7 @@ namespace GEO {
 	bool& cell_is_on_boundary,
 	bool& cell_is_outside_cube,
 	IncidentTetrahedra& W
-    ) {	
+    ) {
 	// Integer translations associated with the six plane equations
 	// Note: indexing matches code below (order of the clipping
 	// operations).
@@ -3706,14 +3706,14 @@ namespace GEO {
 
 	copy_Laguerre_cell_from_Delaunay(v, C, W);
 	geo_assert(!C.empty());
-	    
+
 	// Determine the periodic instances of the vertex to be created
 	// ************************************************************
 	//   - Find all the inresected boundary faces
 	//   - The instances to create correspond to all the possible
 	//     sums of translation vectors associated with the
 	//     intersected boundary faces
-	
+
 	FOR(i,27) {
 	    use_instance[i] = false;
 	}
@@ -3723,15 +3723,15 @@ namespace GEO {
 	C.clip_by_plane(vec4( 1.0, 0.0, 0.0,  0.0));
 	C.clip_by_plane(vec4(-1.0, 0.0, 0.0,  period_));
 	C.clip_by_plane(vec4( 0.0, 1.0, 0.0,  0.0));
-	C.clip_by_plane(vec4( 0.0,-1.0, 0.0,  period_));	
+	C.clip_by_plane(vec4( 0.0,-1.0, 0.0,  period_));
 	C.clip_by_plane(vec4( 0.0, 0.0, 1.0,  0.0));
 	C.clip_by_plane(vec4( 0.0, 0.0,-1.0,  period_));
 
 	cell_is_outside_cube = false;
 	cell_is_on_boundary = false;
-	
+
 	if(C.empty()) {
-	    // Special case: cell is completely outside the cube.	    
+	    // Special case: cell is completely outside the cube.
 	    cell_is_outside_cube = true;
 	    copy_Laguerre_cell_from_Delaunay(v, C, W);
 	    // Clip the cell with the 3x3x3 (rubic's) cube that
@@ -3742,14 +3742,14 @@ namespace GEO {
 	    C.clip_by_plane(vec4( 1.0, 0.0, 0.0,  period_));
 	    C.clip_by_plane(vec4(-1.0, 0.0, 0.0,  2.0*period_));
 	    C.clip_by_plane(vec4( 0.0, 1.0, 0.0,  period_));
-	    C.clip_by_plane(vec4( 0.0,-1.0, 0.0,  2.0*period_));	
+	    C.clip_by_plane(vec4( 0.0,-1.0, 0.0,  2.0*period_));
 	    C.clip_by_plane(vec4( 0.0, 0.0, 1.0,  period_));
 	    C.clip_by_plane(vec4( 0.0, 0.0,-1.0,  2.0*period_));
 
 	    // Normally we cannot have an empty cell, empty cells were
 	    // detected before.
 	    geo_assert(!C.empty());
-	    
+
 	    // Now detect the bounds of the sub-(rubic's) cube overlapped
 	    // by the cell.
 	    int TXmin = 0, TXmax = 0,
@@ -3769,10 +3769,10 @@ namespace GEO {
 	    }
 	    if(C.cell_has_conflict(vec4( 0.0, 0.0, 1.0,  0.0))) {
 		TZmin = -1;
-	    } 
+	    }
 	    if(C.cell_has_conflict(vec4( 0.0, 0.0,-1.0,  period_))) {
 		TZmax = 1;
-	    } 
+	    }
 	    for(int TX = TXmin; TX <= TXmax; ++TX) {
 		for(int TY = TYmin; TY <= TYmax; ++TY) {
 		    for(int TZ = TZmin; TZ <= TZmax; ++TZ) {
@@ -3787,7 +3787,7 @@ namespace GEO {
 	    //   - The instances to create correspond to all the possible
 	    //     sums of translation vectors associated with the
 	    //     intersected boundary faces
-	    
+
 	    // Traverse all the Voronoi vertices of the face
 	    for(
 		VBW::ushort t = C.first_triangle();
@@ -3837,7 +3837,7 @@ namespace GEO {
 	}
 	return result;
     }
-    
+
     void PeriodicDelaunay3d::handle_periodic_boundaries() {
 
 	// Update pointers so that queries function will work (even in our
@@ -3854,14 +3854,14 @@ namespace GEO {
 	if(stores_cicl()) {
 	    update_cicl();
 	}
-	
+
 	for(index_t v=0; v<nb_vertices_non_periodic_; ++v) {
 	    if(v_to_cell_[v] == -1) {
 		has_empty_cells_ = true;
 		return;
 	    }
 	}
-	
+
 	// -----------------------------------------------------------
 	// Phase I: find the cells that intersect the boundaries, and
 	// create periodic vertices for each possible translation.
@@ -3871,14 +3871,14 @@ namespace GEO {
 	// Each bit of vertex_instances_[v] indicates which instance
 	// is used.
 	vertex_instances_.assign(nb_vertices_non_periodic_,1);
-	
+
 	index_t nb_cells_on_boundary = 0;
 	index_t nb_cells_outside_cube = 0;
 
-	Process::spinlock lock = GEOGRAM_SPINLOCK_INIT;
+	Process::spinlock lock;
 
 	parallel_for_slice(
-	    0, nb_vertices_non_periodic_,		     
+	    0, nb_vertices_non_periodic_,
 	    [this,&lock,&nb_cells_on_boundary,&nb_cells_outside_cube](
 		index_t from, index_t to
 	    ) {
@@ -3890,7 +3890,7 @@ namespace GEO {
 		  bool use_instance[27];
 		  bool cell_is_on_boundary = false;
 		  bool cell_is_outside_cube = false;
-		  
+
 		  // Determines the periodic vertices to create, that is,
 		  // whenever the cell of the current vertex has an intersection
 		  // with one of the 27 cubes, an instance needs to be created there.
@@ -3902,7 +3902,7 @@ namespace GEO {
 
 
 		  Process::acquire_spinlock(lock);
-		  
+
 		  if(cell_is_on_boundary) {
 		      ++nb_cells_on_boundary;
 		  }
@@ -3910,7 +3910,7 @@ namespace GEO {
 		  if(cell_is_outside_cube) {
 		      ++nb_cells_outside_cube;
 		  }
-	    
+
 		  // Append the new periodic vertices in the list of vertices.
 		  // (we put them in the reorder_ vector that is always used
 		  //  to do the insertions).
@@ -3922,8 +3922,8 @@ namespace GEO {
 			  }
 		      }
 		  }
-		  
-		  Process::release_spinlock(lock);		
+
+		  Process::release_spinlock(lock);
 	      }
 	   }
 	);
@@ -3946,17 +3946,17 @@ namespace GEO {
 	// vertices (the periodic_v_to_cell_ table).
 	update_periodic_v_to_cell_ = true;
 	update_v_to_cell();
-	update_periodic_v_to_cell_ = false;	    	    
+	update_periodic_v_to_cell_ = false;
 	if(stores_cicl()) {
 	    update_cicl();
 	}
 
 	index_t nb_vertices_phase_I = reorder_.size();
 
-	// -----------------------------------------------------------	
+	// -----------------------------------------------------------
 	// Phase II: Insert the real neighbors of the virtual vertices,
 	//  back-translated to the original position.
-	// -----------------------------------------------------------		
+	// -----------------------------------------------------------
 
 	{
 	    IncidentTetrahedra W;
@@ -3966,12 +3966,12 @@ namespace GEO {
 	    // that we will modify.
 	    vector<index_t> vertex_instances = vertex_instances_;
 	    for(index_t v=0; v<nb_vertices_non_periodic_; ++v) {
-		
+
 		for(index_t instance=1; instance<27; ++instance) {
 		    int vTx = translation[instance][0];
 		    int vTy = translation[instance][1];
 		    int vTz = translation[instance][2];
-		    
+
 		    if((vertex_instances_[v] & (1u << instance)) != 0) {
 			index_t vp = make_periodic_vertex(v, instance);
 			get_incident_tets(vp, W);
@@ -4017,15 +4017,15 @@ namespace GEO {
 
     void PeriodicDelaunay3d::check_volume() {
 	ConvexCell C;
-	C.use_exact_predicates(convex_cell_exact_predicates_);	
-	
+	C.use_exact_predicates(convex_cell_exact_predicates_);
+
 	Logger::out("Periodic") << "Checking total volume..." << std::endl;
 	double sumV = 0;
 	IncidentTetrahedra W;
-	
+
 	FOR(v, nb_vertices_non_periodic_) {
 	    copy_Laguerre_cell_from_Delaunay(v, C, W);
-#ifdef GEO_DEBUG	    
+#ifdef GEO_DEBUG
 	    for(
 		VBW::ushort t = C.first_triangle();
 		t!=VBW::END_OF_LIST; t=C.next_triangle(t)
@@ -4035,13 +4035,13 @@ namespace GEO {
 		    geo_debug_assert(C.triangle_v_local_index(t,lv) != 0);
 		}
 	    }
-#endif	    
+#endif
 	    C.compute_geometry();
 	    sumV += C.volume();
 	}
 
 	double expectedV = period_*period_*period_;
-	
+
 	Logger::out("Periodic") << "Sum volumes = " << sumV << std::endl;
 	Logger::out("Periodic") << "  (expected " <<  expectedV << ")"
 				<< std::endl;
@@ -4051,7 +4051,7 @@ namespace GEO {
 				 << std::endl;
 	    exit(-1);
 	}
-	
+
     }
 
     void PeriodicDelaunay3d::save_cells(
@@ -4063,12 +4063,12 @@ namespace GEO {
 	while(index_string.length() < 3) {
 	    index_string = "0" + index_string;
 	}
-	
+
 	std::ofstream out((basename+index_string+".obj").c_str());
 	index_t v_off = 1;
-	
+
 	ConvexCell C;
-	C.use_exact_predicates(convex_cell_exact_predicates_);		
+	C.use_exact_predicates(convex_cell_exact_predicates_);
 	IncidentTetrahedra W;
 	for(index_t vv=0; vv<nb_vertices_non_periodic_; ++vv) {
 	    copy_Laguerre_cell_from_Delaunay(vv, C, W);
@@ -4076,7 +4076,7 @@ namespace GEO {
 		C.clip_by_plane(vec4( 1.0, 0.0, 0.0,  0.0));
 		C.clip_by_plane(vec4(-1.0, 0.0, 0.0,  period_));
 		C.clip_by_plane(vec4( 0.0, 1.0, 0.0,  0.0));
-		C.clip_by_plane(vec4( 0.0,-1.0, 0.0,  period_));	
+		C.clip_by_plane(vec4( 0.0,-1.0, 0.0,  period_));
 		C.clip_by_plane(vec4( 0.0, 0.0, 1.0,  0.0));
 		C.clip_by_plane(vec4( 0.0, 0.0,-1.0,  period_));
 	    }

--- a/src/lib/geogram/numerics/lbfgs_optimizers.cpp
+++ b/src/lib/geogram/numerics/lbfgs_optimizers.cpp
@@ -13,7 +13,7 @@
  *  * Neither the name of the ALICE Project-Team nor the names of its
  *  contributors may be used to endorse or promote products derived from this
  *  software without specific prior written permission.
- * 
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -36,9 +36,9 @@
  *     http://www.loria.fr/~levy
  *
  *     ALICE Project
- *     LORIA, INRIA Lorraine, 
+ *     LORIA, INRIA Lorraine,
  *     Campus Scientifique, BP 239
- *     54506 VANDOEUVRE LES NANCY CEDEX 
+ *     54506 VANDOEUVRE LES NANCY CEDEX
  *     FRANCE
  *
  */
@@ -68,10 +68,10 @@ namespace GEO {
      */
     namespace OptimizerConfig {
 
-        static Optimizer::newiteration_callback newiteration_callback_ = nullptr;
-        static Optimizer::funcgrad_callback funcgrad_callback_ = nullptr;
-        static Optimizer::evalhessian_callback evalhessian_callback_ = nullptr;
-        static index_t N_ = 0;
+        static thread_local Optimizer::newiteration_callback newiteration_callback_ = nullptr;
+        static thread_local Optimizer::funcgrad_callback funcgrad_callback_ = nullptr;
+        static thread_local Optimizer::evalhessian_callback evalhessian_callback_ = nullptr;
+        static thread_local index_t N_ = 0;
 
         /**
          * \brief Initializes Optimizer configuration
@@ -250,7 +250,7 @@ namespace GEO {
         hlbfgs_info[4] = (int) max_iter_;  // max iterations
         hlbfgs_info[6] = (int) T_;  // update interval of hessian
         hlbfgs_info[7] = 1;   // 0: without hessian, 1: with accurate hessian
-        
+
         HLBFGS(
             (int) n_,
             (int) m_,

--- a/src/lib/geogram/numerics/multi_precision.cpp
+++ b/src/lib/geogram/numerics/multi_precision.cpp
@@ -13,7 +13,7 @@
  *  * Neither the name of the ALICE Project-Team nor the names of its
  *  contributors may be used to endorse or promote products derived from this
  *  software without specific prior written permission.
- * 
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -36,9 +36,9 @@
  *     http://www.loria.fr/~levy
  *
  *     ALICE Project
- *     LORIA, INRIA Lorraine, 
+ *     LORIA, INRIA Lorraine,
  *     Campus Scientifique, BP 239
- *     54506 VANDOEUVRE LES NANCY CEDEX 
+ *     54506 VANDOEUVRE LES NANCY CEDEX
  *     FRANCE
  *
  */
@@ -60,7 +60,7 @@ namespace {
     using namespace GEO;
 
     /************************************************************************/
-    
+
     bool expansion_length_stat_ = false;
     std::vector<index_t> expansion_length_histo_;
 
@@ -89,11 +89,11 @@ namespace {
     /************************************************************************/
 
     /**
-     * \brief An optimized memory allocator for objects of 
+     * \brief An optimized memory allocator for objects of
      *  small size.
      * \details It is used by the high-level class expansion_nt
      *  that allocates expansion objects on the heap. PCK predicates
-     *  do not use it (they use the more efficient low-level API 
+     *  do not use it (they use the more efficient low-level API
      *  that allocates expansion objects on the stack).
      */
     class Pools {
@@ -149,17 +149,17 @@ namespace {
             pools_[size] = ptr;
         }
 
-        
+
     protected:
         /**
          * \brief Number of elements in each individual chunk
          *  allocation.
          */
         static const index_t POOL_CHUNK_SIZE = 512;
-        
+
         /**
          * \brief Allocates a new chunk of elements and prepends
-         *  it to the free list for allocations of the specified 
+         *  it to the free list for allocations of the specified
          *  size.
          * \param[in] size_in size of the elements to be allocated.
          */
@@ -177,14 +177,14 @@ namespace {
             chunks_.push_back(chunk);
         }
 
-        
+
     private:
         /**
          * \brief The free lists of the pools. Index corresponds
          *  to element size in bytes.
          */
         std::vector<void*> pools_;
-        
+
         /**
          * \brief Pointers to all the allocated chunks.
          * \details Used by the destructor to release all the
@@ -195,9 +195,9 @@ namespace {
     };
 
     static Pools pools_;
-    
+
     /************************************************************************/
-    
+
     /**
      * \brief Computes the sum of two doubles into a length 2 expansion.
      * \details By Jonathan Shewchuk.
@@ -213,7 +213,7 @@ namespace {
         y = b - bvirt;
     }
 
-#ifdef REMOVE_ME        
+#ifdef REMOVE_ME
     /**
      * \brief Computes the difference of two doubles into a length 2 expansion.
      * \details By Jonathan Shewchuk.
@@ -229,7 +229,7 @@ namespace {
         y = bvirt - b;
     }
 #endif
-    
+
     /**
      * \brief Computes the sum of a length 2 expansion and a double
      *  into a length 3 expansion.
@@ -748,8 +748,8 @@ namespace GEO {
         expansion_splitter_ += 1.0;
     }
 
-    static Process::spinlock expansions_lock = GEOGRAM_SPINLOCK_INIT;
-    
+    static Process::spinlock expansions_lock;
+
     expansion* expansion::new_expansion_on_heap(index_t capa) {
 	Process::acquire_spinlock(expansions_lock);
         if(expansion_length_stat_) {
@@ -767,9 +767,9 @@ namespace GEO {
     }
 
     void expansion::delete_expansion_on_heap(expansion* e) {
-	Process::acquire_spinlock(expansions_lock);	
+	Process::acquire_spinlock(expansions_lock);
         pools_.free(e, expansion::bytes(e->capacity()));
-	Process::release_spinlock(expansions_lock);	
+	Process::release_spinlock(expansions_lock);
     }
 
     // ====== Initialization from expansion and double ===============
@@ -1004,7 +1004,7 @@ namespace GEO {
             expansion& d1 = expansion_dot_at(p1, p2, p0, dim1);
             expansion& d2 = expansion_dot_at(p1_2, p2_2, p0_2, dim2);
             this->assign_sum(d1, d2);
-        } 
+        }
         return *this;
     }
 
@@ -1017,11 +1017,11 @@ namespace GEO {
         this->assign_sum(x2,y2,z2);
         return *this;
     }
-    
+
     /************************************************************************/
 
     Sign sign_of_expansion_determinant(
-        const expansion& a00,const expansion& a01,  
+        const expansion& a00,const expansion& a01,
         const expansion& a10,const expansion& a11
     ) {
         const expansion& result = expansion_det2x2(a00, a01, a10, a11);
@@ -1035,7 +1035,7 @@ namespace GEO {
     ) {
         // First compute the det2x2
         const expansion& m01 =
-            expansion_det2x2(a00, a10, a01, a11); 
+            expansion_det2x2(a00, a10, a01, a11);
         const expansion& m02 =
             expansion_det2x2(a00, a20, a01, a21);
         const expansion& m12 =
@@ -1049,7 +1049,7 @@ namespace GEO {
         const expansion& result = expansion_sum3(z1,z2,z3);
         return result.sign();
     }
-    
+
     Sign sign_of_expansion_determinant(
         const expansion& a00,const expansion& a01,
         const expansion& a02,const expansion& a03,
@@ -1058,10 +1058,10 @@ namespace GEO {
         const expansion& a20,const expansion& a21,
         const expansion& a22,const expansion& a23,
         const expansion& a30,const expansion& a31,
-        const expansion& a32,const expansion& a33 
+        const expansion& a32,const expansion& a33
     ) {
 
-        // First compute the det2x2        
+        // First compute the det2x2
         const expansion& m01 =
             expansion_det2x2(a10,a00,a11,a01);
         const expansion& m02 =
@@ -1073,8 +1073,8 @@ namespace GEO {
         const expansion& m13 =
             expansion_det2x2(a30,a10,a31,a11);
         const expansion& m23 =
-            expansion_det2x2(a30,a20,a31,a21);     
-        
+            expansion_det2x2(a30,a20,a31,a21);
+
         // Now compute the minors of rank 3
         const expansion& m012_1 = expansion_product(m12,a02);
         expansion& m012_2 = expansion_product(m02,a12); m012_2.negate();
@@ -1083,10 +1083,10 @@ namespace GEO {
 
         const expansion& m013_1 = expansion_product(m13,a02);
         expansion& m013_2 = expansion_product(m03,a12); m013_2.negate();
-        
+
         const expansion& m013_3 = expansion_product(m01,a32);
         const expansion& m013 = expansion_sum3(m013_1, m013_2, m013_3);
-        
+
         const expansion& m023_1 = expansion_product(m23,a02);
         expansion& m023_2 = expansion_product(m03,a22); m023_2.negate();
         const expansion& m023_3 = expansion_product(m02,a32);
@@ -1096,7 +1096,7 @@ namespace GEO {
         expansion& m123_2 = expansion_product(m13,a22); m123_2.negate();
         const expansion& m123_3 = expansion_product(m12,a32);
         const expansion& m123 = expansion_sum3(m123_1, m123_2, m123_3);
-        
+
         // Now compute the minors of rank 4
         const expansion& m0123_1 = expansion_product(m123,a03);
         const expansion& m0123_2 = expansion_product(m023,a13);
@@ -1109,8 +1109,8 @@ namespace GEO {
         const expansion& result = expansion_diff(z1,z2);
         return result.sign();
     }
-    
+
     /************************************************************************/
-    
+
 }
 

--- a/src/lib/geogram/third_party/HLBFGS/LineSearch.cpp
+++ b/src/lib/geogram/third_party/HLBFGS/LineSearch.cpp
@@ -14,17 +14,17 @@ int MCSRCH(
     int *keep, double *rkeep, double *cg_dginit
 ) {
         /* Local variables */
-        static double dg, fm, fx, fy, dgm, dgx, dgy, fxm, fym, stx, sty;
-        static double dgxm, dgym;
+        static thread_local double dg, fm, fx, fy, dgm, dgx, dgy, fxm, fym, stx, sty;
+        static thread_local double dgxm, dgym;
 
-        static int infoc;
-        static double finit;
-        static double width;
-        static double stmin, stmax;
-        static bool stage1;
-        static double width1, ftest1;
-        static bool brackt;
-        static double dginit, dgtest;
+        static thread_local int infoc;
+        static thread_local double finit;
+        static thread_local double width;
+        static thread_local double stmin, stmax;
+        static thread_local bool stage1;
+        static thread_local double width1, ftest1;
+        static thread_local bool brackt;
+        static thread_local double dginit, dgtest;
 
         /* Parameter adjustments */
         --rkeep;
@@ -101,8 +101,8 @@ L30: if (brackt)
          *stp = std::max<double>(*stp, *stpmin);
          *stp = std::min<double>(*stp, *stpmax);
          if (
-             (brackt && (*stp <= stmin || *stp >= stmax)) || 
-             *nfev >= *maxfev - 1 || infoc == 0 || 
+             (brackt && (*stp <= stmin || *stp >= stmax)) ||
+             *nfev >= *maxfev - 1 || infoc == 0 ||
              (brackt && stmax - stmin <= *xtol * stmax)
          ) {
                  *stp = stx;
@@ -147,8 +147,8 @@ L45: *info = 0;
          else
          {
              //if (*f <= ftest1 &&  (dg >= *gtol * dginit ||
-             //     dg <= (2.0- (*gtol) ) * dginit) )  //TNPACK's C2 version. 
-             
+             //     dg <= (2.0- (*gtol) ) * dginit) )  //TNPACK's C2 version.
+
                  if (*f <= ftest1 && std::fabs(dg) <= *gtol * (-dginit))
                  {
                          *info = 1;
@@ -237,18 +237,18 @@ int MCSTEP(double *stx, double *fx, double *dx, double *sty, double *fy,
         double d__1, d__2, d__3;
 
         /* Local variables */
-        static double p, q, r__, s, gama, sgnd, stpc, stpf, stpq, theta;
-        static bool bound;
+        static thread_local double p, q, r__, s, gama, sgnd, stpc, stpf, stpq, theta;
+        static thread_local bool bound;
 
 #ifdef SAFE_SEARCH
         /*     copy from TNPACK */
-        static double xsafe;
+        static thread_local double xsafe;
         xsafe = .001;
 #endif
         *info = 0;
         if (
             (
-                *brackt && (*stp <= std::min<double>(*stx, *sty) || 
+                *brackt && (*stp <= std::min<double>(*stx, *sty) ||
                             *stp >= std::max<double>(*stx, *sty))
              ) || *dx * (*stp - *stx) >= 0. || *stpmax < *stpmin
         ) {


### PR DESCRIPTION
Tracked down race conditions in geogram using ThreadSanitizer. Apparently the spinlock implementation in geogram is also subject to race condition, so I switched to tbb's spinlocks instead. Performances may be impacted, although we'd need to benchmark the effects.