### PR TITLE
Dont try to reorient faces

### DIFF
--- a/src/lib/geogram/mesh/mesh_intersection.cpp
+++ b/src/lib/geogram/mesh/mesh_intersection.cpp
@@ -161,7 +161,7 @@ namespace {
      */
     index_t remove_intersecting_facets(Mesh& M, index_t nb_neigh = 0) {
         geo_assert(M.vertices.dimension() >= 3);
-        mesh_repair(M, MESH_REPAIR_DEFAULT & ~MESH_REPAIR_ORIENT);  // it repairs and triangulates.
+        mesh_repair(M, MeshRepairMode(MESH_REPAIR_DEFAULT & ~MESH_REPAIR_ORIENT));  // it repairs and triangulates.
 
         vector<index_t> has_intersection;
         StoreIntersections action(M, has_intersection);

--- a/src/lib/geogram/mesh/mesh_intersection.cpp
+++ b/src/lib/geogram/mesh/mesh_intersection.cpp
@@ -161,7 +161,7 @@ namespace {
      */
     index_t remove_intersecting_facets(Mesh& M, index_t nb_neigh = 0) {
         geo_assert(M.vertices.dimension() >= 3);
-        mesh_repair(M, MESH_REPAIR_DEFAULT);  // it repairs and triangulates.
+        mesh_repair(M, MESH_REPAIR_DEFAULT & ~MESH_REPAIR_ORIENT);  // it repairs and triangulates.
 
         vector<index_t> has_intersection;
         StoreIntersections action(M, has_intersection);

--- a/src/lib/geogram/mesh/mesh_repair.cpp
+++ b/src/lib/geogram/mesh/mesh_repair.cpp
@@ -1110,7 +1110,11 @@ namespace GEO {
         );
 
         repair_connect_facets(M);
-        repair_reorient_facets_anti_moebius(M);
+
+        if(mode & MESH_REPAIR_ORIENT) {
+            repair_reorient_facets_anti_moebius(M);
+        }
+
         repair_split_non_manifold_vertices(M);
 
         if(

--- a/src/lib/geogram/mesh/mesh_repair.h
+++ b/src/lib/geogram/mesh/mesh_repair.h
@@ -70,9 +70,11 @@ namespace GEO {
         MESH_REPAIR_TRIANGULATE = 4,  /**< Triangulates mesh                  */
         MESH_REPAIR_RECONSTRUCT = 8,  /**< Post-process result of Co3Ne algo. */
         MESH_REPAIR_QUIET       = 16, /**< Do not display any message.        */
+        MESH_REPAIR_ORIENT      = 32, /**< Reorient faces.        */
         MESH_REPAIR_DEFAULT =
             MESH_REPAIR_COLOCATE |
             MESH_REPAIR_DUP_F |
+            MESH_REPAIR_ORIENT |
             MESH_REPAIR_TRIANGULATE
             /**< Fits most uses */
     };


### PR DESCRIPTION
This adds an option to mesh_repair to avoid flipping the orientation. Furthermore the remove_self_intersections functions was modified to apply the flipping heuristic when calling mesh repair.