### PR TITLE
Revert Jérémie's unfortunate indentation to help merging newer geogram versions

### DIFF
--- a/src/lib/geogram/CMakeLists.txt
+++ b/src/lib/geogram/CMakeLists.txt
@@ -61,6 +61,8 @@ if(WIN32)
     target_link_libraries(geogram psapi)
 endif()
 
+target_compile_features(geogram PUBLIC cxx_std_17)
+
 # Install the library
 install_devkit_targets(geogram)
 

--- a/src/lib/geogram/basic/disable_warnings.h
+++ b/src/lib/geogram/basic/disable_warnings.h
@@ -1,0 +1,73 @@
+
+// Disable compiler warnings before including third party code
+#if defined(__clang__)
+	#pragma clang diagnostic push
+	#pragma clang diagnostic ignored "-Wshadow"
+	#pragma clang diagnostic push
+	#pragma clang diagnostic ignored "-Wsign-compare"
+	#pragma clang diagnostic push
+	#pragma clang diagnostic ignored "-Wswitch-default"
+	#pragma clang diagnostic push
+	#pragma clang diagnostic ignored "-Wformat-nonliteral"
+	#pragma clang diagnostic push
+	#pragma clang diagnostic ignored "-Wswitch-enum"
+	#pragma clang diagnostic push
+	#pragma clang diagnostic ignored "-Wstrict-overflow"
+	// #pragma clang diagnostic push
+	// #pragma clang diagnostic ignored "-Wnoexcept"
+	#pragma clang diagnostic push
+	#pragma clang diagnostic ignored "-Wctor-dtor-privacy"
+	#pragma clang diagnostic push
+	#pragma clang diagnostic ignored "-Wnull-dereference"
+	#pragma clang diagnostic push
+	#pragma clang diagnostic ignored "-Wcast-qual"
+	#pragma clang diagnostic push
+	#pragma clang diagnostic ignored "-Wmissing-noreturn"
+	#pragma clang diagnostic push
+	#pragma clang diagnostic ignored "-Woverloaded-virtual"
+	#pragma clang diagnostic push
+	#pragma clang diagnostic ignored "-Wsign-promo"
+	#pragma clang diagnostic push
+	#pragma clang diagnostic ignored "-Wcast-align"
+	#pragma clang diagnostic push
+	#pragma clang diagnostic ignored "-Wnull-pointer-arithmetic"
+	#pragma clang diagnostic push
+	#pragma clang diagnostic ignored "-Wc++17-extensions"
+	#pragma clang diagnostic push
+	#pragma clang diagnostic ignored "-Wsign-conversion"
+#elif (defined(__GNUC__) || defined(__GNUG__)) && !(defined(__clang__) || defined(__INTEL_COMPILER))
+	#pragma GCC diagnostic push
+	#pragma GCC diagnostic ignored "-Wshadow"
+	#pragma GCC diagnostic push
+	#pragma GCC diagnostic ignored "-Wsign-compare"
+	#pragma GCC diagnostic push
+	#pragma GCC diagnostic ignored "-Wswitch-default"
+	#pragma GCC diagnostic push
+	#pragma GCC diagnostic ignored "-Wformat-nonliteral"
+	#pragma GCC diagnostic push
+	#pragma GCC diagnostic ignored "-Wswitch-enum"
+	#pragma GCC diagnostic push
+	#pragma GCC diagnostic ignored "-Wstrict-overflow"
+	#pragma GCC diagnostic push
+	#pragma GCC diagnostic ignored "-Wnoexcept"
+	#pragma GCC diagnostic push
+	#pragma GCC diagnostic ignored "-Wctor-dtor-privacy"
+	#pragma GCC diagnostic push
+	#pragma GCC diagnostic ignored "-Wnull-dereference"
+	#pragma GCC diagnostic push
+	#pragma GCC diagnostic ignored "-Wcast-qual"
+	#pragma GCC diagnostic push
+	#pragma GCC diagnostic ignored "-Wmissing-noreturn"
+	#pragma GCC diagnostic push
+	#pragma GCC diagnostic ignored "-Woverloaded-virtual"
+	#pragma GCC diagnostic push
+	#pragma GCC diagnostic ignored "-Wsign-promo"
+	#pragma GCC diagnostic push
+	#pragma GCC diagnostic ignored "-Wstrict-aliasing"
+	#pragma GCC diagnostic push
+	#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
+	#pragma GCC diagnostic push
+	#pragma GCC diagnostic ignored "-Wunused-local-typedefs"
+	#pragma GCC diagnostic push
+	#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif

--- a/src/lib/geogram/basic/enable_warnings.h
+++ b/src/lib/geogram/basic/enable_warnings.h
@@ -1,0 +1,38 @@
+// Reenable the warnings disabled before including third party code
+#if defined(__clang__)
+#pragma clang diagnostic pop // -Wshadow
+#pragma clang diagnostic pop // -Wsign-compare
+#pragma clang diagnostic pop // -Wswitch-default
+#pragma clang diagnostic pop // -Wformat-nonliteral
+#pragma clang diagnostic pop // -Wswitch-enum
+#pragma clang diagnostic pop // -Wstrict-overflow
+// #pragma clang diagnostic pop // -Wnoexcept
+#pragma clang diagnostic pop // -Wctor-dtor-privacy
+#pragma clang diagnostic pop // -Wnull-dereference
+#pragma clang diagnostic pop // -Wcast-qual
+#pragma clang diagnostic pop // -Wmissing-noreturn
+#pragma clang diagnostic pop // -Woverloaded-virtual
+#pragma clang diagnostic pop // -Wsign-promo
+#pragma clang diagnostic pop // -Wcast-align
+#pragma clang diagnostic pop // -Wnull-pointer-arithmetic
+#pragma clang diagnostic pop // -Wc++17-extensions
+#pragma clang diagnostic pop // -Wsign-conversion
+#elif (defined(__GNUC__) || defined(__GNUG__)) && !(defined(__clang__) || defined(__INTEL_COMPILER))
+#pragma GCC diagnostic pop // -Wshadow
+#pragma GCC diagnostic pop // -Wsign-compare
+#pragma GCC diagnostic pop // -Wswitch-default
+#pragma GCC diagnostic pop // -Wformat-nonliteral
+#pragma GCC diagnostic pop // -Wswitch-enum
+#pragma GCC diagnostic pop // -Wstrict-overflow
+#pragma GCC diagnostic pop // -Wnoexcept
+#pragma GCC diagnostic pop // -Wctor-dtor-privacy
+#pragma GCC diagnostic pop // -Wnull-dereference
+#pragma GCC diagnostic pop // -Wcast-qual
+#pragma GCC diagnostic pop // -Wmissing-noreturn
+#pragma GCC diagnostic pop // -Woverloaded-virtual
+#pragma GCC diagnostic pop // -Wsign-promo
+#pragma GCC diagnostic pop // -Wstrict-aliasing
+#pragma GCC diagnostic pop // -Wunused-but-set-variable
+#pragma GCC diagnostic pop // -Wunused-local-typedefs
+#pragma GCC diagnostic pop // -Wsign-conversion
+#endif

--- a/src/lib/geogram/basic/geometry.h
+++ b/src/lib/geogram/basic/geometry.h
@@ -13,7 +13,7 @@
  *  * Neither the name of the ALICE Project-Team nor the names of its
  *  contributors may be used to endorse or promote products derived from this
  *  software without specific prior written permission.
- * 
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -36,9 +36,9 @@
  *     http://www.loria.fr/~levy
  *
  *     ALICE Project
- *     LORIA, INRIA Lorraine, 
+ *     LORIA, INRIA Lorraine,
  *     Campus Scientifique, BP 239
- *     54506 VANDOEUVRE LES NANCY CEDEX 
+ *     54506 VANDOEUVRE LES NANCY CEDEX
  *     FRANCE
  *
  */
@@ -97,7 +97,7 @@ namespace GEO {
      */
     typedef vecng<4, Numeric::float32> vec4f;
 
-   
+
     /**
      * \brief Represents points and vectors in 2d with
      *  integer coordinates.
@@ -118,8 +118,8 @@ namespace GEO {
      * \details Syntax is (mostly) compatible with GLSL.
      */
     typedef vecng<4, Numeric::int32> vec4i;
-   
-   
+
+
     /**
      * \brief Represents a 2x2 matrix.
      * \details Syntax is (mostly) compatible with GLSL.
@@ -289,23 +289,23 @@ namespace GEO {
          * \param[in] p1 , p2 , p3 the three vertices of the triangle
          * \return the area of the triangle (\p p1, \p p2, \p p3).
          */
-	inline double triangle_area_3d(
-	    const double* p1, const double* p2, const double* p3
-	) {
-	    double Ux = p2[0] - p1[0];
-	    double Uy = p2[1] - p1[1];
-	    double Uz = p2[2] - p1[2];
-	    
-	    double Vx = p3[0] - p1[0];
-	    double Vy = p3[1] - p1[1];
-	    double Vz = p3[2] - p1[2];
-	    
-	    double Nx = Uy*Vz - Uz*Vy;
-	    double Ny = Uz*Vx - Ux*Vz;
-	    double Nz = Ux*Vy - Uy*Vx;
-	    return 0.5 * ::sqrt(Nx*Nx+Ny*Ny+Nz*Nz);
-	}
-	
+        inline double triangle_area_3d(
+            const double* p1, const double* p2, const double* p3
+        ) {
+            double Ux = p2[0] - p1[0];
+            double Uy = p2[1] - p1[1];
+            double Uz = p2[2] - p1[2];
+
+            double Vx = p3[0] - p1[0];
+            double Vy = p3[1] - p1[1];
+            double Vz = p3[2] - p1[2];
+
+            double Nx = Uy*Vz - Uz*Vy;
+            double Ny = Uz*Vx - Ux*Vz;
+            double Nz = Ux*Vy - Uy*Vx;
+            return 0.5 * ::sqrt(Nx*Nx+Ny*Ny+Nz*Nz);
+        }
+
         /**
          * \brief Computes the area of a 3d triangle
          * \param[in] p1 , p2 , p3 the three vertices of the triangle
@@ -328,13 +328,12 @@ namespace GEO {
         inline double triangle_signed_area_2d(
             const double* p1, const double* p2, const double* p3
         ) {
-	    double a = p2[0]-p1[0];
-	    double b = p3[0]-p1[0];
-	    double c = p2[1]-p1[1];
-	    double d = p3[1]-p1[1];
-	    return 0.5*(a*d-b*c);
+           double a = p2[0]-p1[0];
+           double b = p3[0]-p1[0];
+           double c = p2[1]-p1[1];
+           double d = p3[1]-p1[1];
+           return 0.5*(a*d-b*c);
         }
-	
         /**
          * \brief Computes the area of a 2d triangle
          * \param[in] p1 first vertex of the triangle
@@ -372,9 +371,9 @@ namespace GEO {
         inline double triangle_area_2d(
             const double* p1, const double* p2, const double* p3
         ) {
-	    return ::fabs(triangle_signed_area_2d(p1,p2,p3));
-	}
-	
+            return ::fabs(triangle_signed_area_2d(p1,p2,p3));
+        }
+
         /**
          * \brief Computes the center of the circumscribed circle of
          *   a 2d triangle.
@@ -515,6 +514,38 @@ namespace GEO {
         }
 
         /**
+         * \brief Computes the centroid of a 3d tetrahedron with weighted points.
+         * \details The integrated weight varies linearly in the tetrahedron.
+         * \param[in] p first vertex of the tetrahedron
+         * \param[in] q second vertex of the tetrahedron
+         * \param[in] r third vertex of the tetrahedron
+         * \param[in] s fourth vertex of the tetrahedron
+         * \param[in] a the weight associated with vertex \p p
+         * \param[in] b the weight associated with vertex \p q
+         * \param[in] c the weight associated with vertex \p r
+         * \param[in] d the weight associated with vertex \p s
+         * \param[out] Vg the total weight times the centroid
+         * \param[out] V the total weight
+         */
+        inline void tetra_centroid(
+            const vec3& p, const vec3& q, const vec3& r, const vec3& s,
+            double a, double b, double c, double d,
+            vec3& Vg, double& V
+        ) {
+            double abcd = a + b + c + d;
+            double volume = Geom::tetra_volume(p, q, r, s);
+            V = volume / 4.0 * abcd;
+            double wp = a + abcd;
+            double wq = b + abcd;
+            double wr = c + abcd;
+            double ws = d + abcd;
+            double t = volume / 20.0;
+            Vg.x = t * (wp * p.x + wq * q.x + wr * r.x + ws * s.x);
+            Vg.y = t * (wp * p.y + wq * q.y + wr * r.y + ws * s.y);
+            Vg.z = t * (wp * p.z + wq * q.z + wr * r.z + ws * s.z);
+        }
+
+        /**
          * \brief Computes the mass of a 3d triangle with weighted points.
          * \details The integrated weight varies linearly in the triangle.
          * \param[in] p first vertex of the triangle
@@ -538,7 +569,7 @@ namespace GEO {
         /**
          * \brief Generates a random point in a 3d triangle.
          * \details Uses Greg Turk's second method.
-         *  Reference: Greg Turk, Generating Random Points 
+         *  Reference: Greg Turk, Generating Random Points
          *  in Triangles, Graphics Gems, p. 24-28, code: p. 649-650.
          * \param[in] p1 first vertex of the triangle
          * \param[in] p2 second vertex of the triangle
@@ -717,10 +748,10 @@ namespace GEO {
                 result[i] += v[j] * m(j,i) ;
             }
         }
-        
+
         return vecng<3,FT>(
             result[0], result[1], result[2]
-        ) ; 
+        ) ;
     }
 
     /**
@@ -744,7 +775,7 @@ namespace GEO {
     ){
         index_t i,j ;
         FT result[4] ;
-        
+
         for(i=0; i<4; i++) {
             result[i] = 0 ;
         }
@@ -754,12 +785,12 @@ namespace GEO {
             }
             result[i] += m(3,i);
         }
-    
+
         return vecng<3,FT>(
             result[0] / result[3],
             result[1] / result[3],
-            result[2] / result[3] 
-        ) ; 
+            result[2] / result[3]
+        ) ;
     }
 
     /**
@@ -778,18 +809,18 @@ namespace GEO {
     ) {
         index_t i,j ;
         FT res[4] = {FT(0), FT(0), FT(0), FT(0)};
-        
+
         for(i=0; i<4; i++) {
             for(j=0; j<4; j++) {
                 res[i] += v[j] * m(j,i) ;
             }
         }
-    
-        return vecng<4,FT>(res[0], res[1], res[2], res[3]) ; 
+
+        return vecng<4,FT>(res[0], res[1], res[2], res[3]) ;
     }
 
     /******************************************************************/
-    
+
     /**
      * \brief Creates a translation matrix from a vector.
      * \details The translation matrix is in homogeneous coordinates,
@@ -806,7 +837,7 @@ namespace GEO {
         result(3,2) = T.z;
         return result;
     }
-    
+
     /**
      * \brief Creates a scaling matrix.
      * \details The scaling matrix is in homogeneous coordinates,
@@ -820,12 +851,12 @@ namespace GEO {
         result.load_identity();
         result(0,0) = s;
         result(1,1) = s;
-        result(2,2) = s;        
+        result(2,2) = s;
         return result;
     }
-    
-    /******************************************************************/    
-    
+
+    /******************************************************************/
+
 }
 
 #endif

--- a/src/lib/geogram/basic/geometry_nd.h
+++ b/src/lib/geogram/basic/geometry_nd.h
@@ -13,7 +13,7 @@
  *  * Neither the name of the ALICE Project-Team nor the names of its
  *  contributors may be used to endorse or promote products derived from this
  *  software without specific prior written permission.
- * 
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -36,9 +36,9 @@
  *     http://www.loria.fr/~levy
  *
  *     ALICE Project
- *     LORIA, INRIA Lorraine, 
+ *     LORIA, INRIA Lorraine,
  *     Campus Scientifique, BP 239
- *     54506 VANDOEUVRE LES NANCY CEDEX 
+ *     54506 VANDOEUVRE LES NANCY CEDEX
  *     FRANCE
  *
  */
@@ -58,6 +58,13 @@
 namespace GEO {
 
     namespace Geom {
+
+        /* Forward declaration */
+        double tetra_volume_from_edge_lengths(
+            double u, double U,
+            double v, double V,
+            double w, double W
+        );
 
         /**
          * \brief Computes the squared distance between two nd points.
@@ -202,6 +209,86 @@ namespace GEO {
             }
         }
 
+        /**
+         * \brief Computes the volume of a nd tetrahedron
+         * \details Uses Heron formula (that computes the area
+         *  from the lengths of the four edges).
+         * \param[in] p1 a pointer to the coordinates of the
+         *  first vertex of the tetrahedron
+         * \param[in] p2 a pointer to the coordinates of the
+         *  second vertex of the tetrahedron
+         * \param[in] p3 a pointer to the coordinates of the
+         *  third vertex of the tetrahedron
+         * \param[in] p4 a pointer to the coordinates of the
+         *  fourth vertex of the tetrahedron
+         * \param[in] dim dimension of the points
+         * \tparam COORD_T the numeric type that represents the coordinates
+         *  of the points
+         * \return the area of tetrahedron ( \p p1, \p p2, \p p3, \p p4)
+         */
+        template <class COORD_T>
+        inline double tetra_volume(
+            const COORD_T* p1,
+            const COORD_T* p2,
+            const COORD_T* p3,
+            const COORD_T* p4,
+            coord_index_t dim
+        ) {
+            double U = distance(p1, p2, dim);
+            double u = distance(p3, p4, dim);
+            double V = distance(p2, p3, dim);
+            double v = distance(p1, p4, dim);
+            double W = distance(p3, p1, dim);
+            double w = distance(p2, p4, dim);
+            return tetra_volume_from_edge_lengths(u, U, v, V, w, W);
+        }
+
+        /**
+         * \brief Computes the centroid of a 3d tetrahedron with weighted points.
+         * \details The integrated weight varies linearly in the tetrahedron.
+         * \param[in] p a pointer to the coordinates of the
+         *  first vertex of the tetrahedron
+         * \param[in] q a pointer to the coordinates of the
+         *  second vertex of the tetrahedron
+         * \param[in] r a pointer to the coordinates of the
+         *  third vertex of the tetrahedron
+         * \param[in] s a pointer to the coordinates of the
+         *  fourth vertex of the tetrahedron
+         * \param[in] a the weight associated with vertex \p p
+         * \param[in] b the weight associated with vertex \p q
+         * \param[in] c the weight associated with vertex \p r
+         * \param[in] d the weight associated with vertex \p s
+         * \param[out] Vg the total weight times the centroid (
+         *  a pointer to a caller-allocated array of dim COORD_T%s)
+         * \param[out] V the total weight
+         * \param[in] dim the dimension of the vertices
+         * \tparam COORD_T the numeric type that represents the coordinates
+         *  of the points
+         */
+        template <class COORD_T>
+        inline void tetra_centroid(
+            const COORD_T* p,
+            const COORD_T* q,
+            const COORD_T* r,
+            const COORD_T* s,
+            COORD_T a, COORD_T b, COORD_T c, COORD_T d,
+            double* Vg,
+            double& V,
+            coord_index_t dim
+        ) {
+            double abcd = a + b + c + d;
+            double volume = Geom::tetra_volume(p, q, r, s, dim);
+            V = volume / 4.0 * abcd;
+            double wp = a + abcd;
+            double wq = b + abcd;
+            double wr = c + abcd;
+            double ws = d + abcd;
+            double t = volume / 20.0;
+            for(coord_index_t i = 0; i < dim; i++) {
+                Vg[i] = t * (wp * p[i] + wq * q[i] + wr * r[i] + ws * s[i]);
+            }
+        }
+
         /********************************************************************/
 
         /**
@@ -330,6 +417,39 @@ namespace GEO {
         }
 
         /**
+         * \brief Computes the centroid of a nd tetrahedron with weighted points.
+         * \details The integrated weight varies linearly in the tetrahedron.
+         * \param[in] p first vertex of the tetrahedron
+         * \param[in] q second vertex of the tetrahedron
+         * \param[in] r third vertex of the tetrahedron
+         * \param[in] s fourth vertex of the tetrahedron
+         * \param[in] a the weight associated with vertex \p p
+         * \param[in] b the weight associated with vertex \p q
+         * \param[in] c the weight associated with vertex \p r
+         * \param[in] s the weight associated with vertex \p s
+         * \param[out] Vg the total weight times the centroid
+         * \param[out] V the total weight
+         * \tparam VEC the class used to represent the vertices
+         *  of the tetrahedron
+         */
+        template <class VEC>
+        inline void tetra_centroid(
+            const VEC& p, const VEC& q, const VEC& r, const VEC& s,
+            double a, double b, double c, double d,
+            VEC& Vg, double& V
+        ) {
+            double abcd = a + b + c + d;
+            double volume = Geom::tetra_volume(p, q, r, s);
+            V = volume / 4.0 * abcd;
+            double wp = a + abcd;
+            double wq = b + abcd;
+            double wr = c + abcd;
+            double ws = d + abcd;
+            double t = volume / 20.0;
+            Vg = t * (wp * p + wq * q + wr * r + ws * s);
+        }
+
+        /**
          * \brief Generates a random point in a nd triangle.
          * \details Uses Greg Turk's second method
          *  (see article in Graphic Gems).
@@ -426,13 +546,13 @@ namespace GEO {
                 lambda0 = 0.0;
                 lambda1 = 1.0;
                 return distance2(point, V1);
-            } 
+            }
             lambda1 = t / l2;
             lambda0 = 1.0-lambda1;
             closest_point = lambda0 * V0 + lambda1 * V1;
             return distance2(point, closest_point);
         }
-        
+
 
         /**
          * \brief Computes the point closest to a given point in a nd segment
@@ -456,7 +576,7 @@ namespace GEO {
                 point, V0, V1, closest_point, lambda0, lambda1
             );
         }
-        
+
         /**
          * \brief Computes the point closest to a given point in a nd triangle
          * \details See
@@ -500,36 +620,36 @@ namespace GEO {
             double t = a01 * b0 - a00 * b1;
             double sqrDistance;
 
-	    // If the triangle is degenerate
-	    if(det < 1e-30) {
-		double cur_l1, cur_l2;
-		VEC cur_closest;
-		double result;
-		double cur_dist = point_segment_squared_distance(point, V0, V1, cur_closest, cur_l1, cur_l2);
-		result = cur_dist;
-		closest_point = cur_closest;
-		lambda0 = cur_l1;
-		lambda1 = cur_l2;
-		lambda2 = 0.0;
-		cur_dist = point_segment_squared_distance(point, V0, V2, cur_closest, cur_l1, cur_l2);
-		if(cur_dist < result) {
-		    result = cur_dist;
-		    closest_point = cur_closest;
-		    lambda0 = cur_l1;
-		    lambda2 = cur_l2;
-		    lambda1 = 0.0;
-		}
-		cur_dist = point_segment_squared_distance(point, V1, V2, cur_closest, cur_l1, cur_l2);
-		if(cur_dist < result) {
-		    result = cur_dist;
-		    closest_point = cur_closest;
-		    lambda1 = cur_l1;
-		    lambda2 = cur_l2;
-		    lambda0 = 0.0;
-		}
-		return result;
-	    }
-	    
+            // If the triangle is degenerate
+            if(det < 1e-30) {
+                double cur_l1, cur_l2;
+                VEC cur_closest;
+                double result;
+                double cur_dist = point_segment_squared_distance(point, V0, V1, cur_closest, cur_l1, cur_l2);
+                result = cur_dist;
+                closest_point = cur_closest;
+                lambda0 = cur_l1;
+                lambda1 = cur_l2;
+                lambda2 = 0.0;
+                cur_dist = point_segment_squared_distance(point, V0, V2, cur_closest, cur_l1, cur_l2);
+                if(cur_dist < result) {
+                    result = cur_dist;
+                    closest_point = cur_closest;
+                    lambda0 = cur_l1;
+                    lambda2 = cur_l2;
+                    lambda1 = 0.0;
+                }
+                cur_dist = point_segment_squared_distance(point, V1, V2, cur_closest, cur_l1, cur_l2);
+                if(cur_dist < result) {
+                    result = cur_dist;
+                    closest_point = cur_closest;
+                    lambda1 = cur_l1;
+                    lambda2 = cur_l2;
+                    lambda0 = 0.0;
+                }
+                return result;
+            }
+
             if(s + t <= det) {
                 if(s < 0.0) {
                     if(t < 0.0) {   // region 4

--- a/src/lib/geogram/basic/process.cpp
+++ b/src/lib/geogram/basic/process.cpp
@@ -523,13 +523,13 @@ namespace GEO {
             max_threads_initialized_ = true;
             if(num_threads == 0) {
                 num_threads = 1;
-            } else if(num_threads > number_of_cores()) {
-                Logger::warn("Process")
-                    << "Cannot allocate " << num_threads
-                    << " for multithreading"
-                    << std::endl;
-                num_threads = number_of_cores();
             }
+            // Previous version of code would test: num_threads > number_of_cores()
+            // and set num_threads = number_of_cores() if condition was true.  
+            // Thread counts in geogram must be tied to input data rather than 
+            // hardware; otherwise, its behavior is non-deterministic.  
+            // Additionally, there is no harm in an over-subscription of tasks.  
+            // In some cases in geogram, it is actually more optimal.  
             max_threads_ = num_threads;
             Logger::out("Process")
                 << "Max used threads = " << max_threads_

--- a/src/lib/geogram/basic/process.cpp
+++ b/src/lib/geogram/basic/process.cpp
@@ -49,6 +49,7 @@
 #include <geogram/basic/string.h>
 #include <geogram/basic/command_line.h>
 #include <geogram/basic/stopwatch.h>
+#include <tbb/tbb.h>
 #include <atomic>
 #include <mutex>
 
@@ -741,47 +742,24 @@ namespace GEO {
         }
     }
 
+    void tbb_parallel_for(index_t from, index_t to, std::function<void(index_t)> func)
+    {
+        auto body = [&func](tbb::blocked_range<index_t> range) {
+            for (auto i = range.begin(); i != range.end(); ++i) {
+                func(i);
+            }
+        };
+        tbb::parallel_for(tbb::blocked_range<index_t>(from, to), body);
+    }
+
 
     void parallel_for_slice(
-	index_t from, index_t to, std::function<void(index_t, index_t)> func,
-        index_t threads_per_core
+        index_t from, index_t to, std::function<void(index_t, index_t)> func
     ) {
-#ifdef GEO_OS_WINDOWS
-        // TODO: This is a limitation of WindowsThreadManager, to be fixed.
-        threads_per_core = 1;
-#endif
-
-        index_t nb_threads = std::min(
-            to - from,
-            Process::maximum_concurrent_threads() * threads_per_core
-        );
-
-	nb_threads = std::max(index_t(1), nb_threads);
-
-        index_t batch_size = (to - from) / nb_threads;
-        if(Process::is_running_threads() || nb_threads == 1) {
-	    func(from, to);
-        } else {
-            ThreadGroup threads;
-	    index_t cur = from;
-	    for(index_t i = 0; i < nb_threads; i++) {
-		if(i == nb_threads - 1) {
-		    threads.push_back(
-			new ParallelForSliceThread(
-			    func, cur, to
-			  )
-			);
-		} else {
-		    threads.push_back(
-			new ParallelForSliceThread(
-			    func, cur, cur + batch_size
-                           )
-                        );
-		}
-		cur += batch_size;
-	    }
-            Process::run_threads(threads);
-        }
+        auto body = [&func](tbb::blocked_range<index_t> range) {
+            func(range.begin(), range.end());
+        };
+        tbb::parallel_for(tbb::blocked_range<index_t>(from, to), body);
     }
 
     void parallel(

--- a/src/lib/geogram/basic/process.h
+++ b/src/lib/geogram/basic/process.h
@@ -541,7 +541,7 @@ namespace GEO {
     /**
      * \brief Executes a loop with concurrent threads.
      * \details
-     *   Executes a parallel for loop from index \p to index \p to, calling
+     *   Executes a parallel for loop from index \p from index \p to, calling
      *   functional object \p func at each iteration.
      *
      * Calling parallel_for(func, from, to) is equivalent
@@ -574,6 +574,29 @@ namespace GEO {
         bool interleaved = false
     );
 
+     /**
+     * \brief Executes a loop with concurrent threads using tbb.
+     * \details
+     *   Executes a parallel for loop from index \p from index \p to, calling
+     *   functional object \p func at each iteration.
+     *
+     * Calling parallel_for(func, from, to) is equivalent
+     * to the following loop, computed in parallel:
+     * \code
+     * for(index_t i = from; i < to; i++) {
+     *    func(i)
+     * }
+     * \endcode
+     *
+     * While similar to parallel_for, this function allows for much more 
+     * flexibility (as best used by the system) regarding which indices are 
+     * run by which threads.  If called by a tbb worker thread, any threads
+     * available to that thread's context are available to this.
+     */
+     void GEOGRAM_API tbb_parallel_for(
+         index_t from, index_t to, std::function<void(index_t)> func
+     );
+
     /**
      * \brief Executes a loop with concurrent threads.
      *
@@ -590,8 +613,8 @@ namespace GEO {
      *   ...
      *   func(in, to);
      * \endcode
-     * where i1,i2,...in are automatically generated. Typically one interval
-     * per physical core is generated.
+     * where i1,i2,...in are automatically generated. Uses tbb for 
+     * implementation.
      *
      * \param[in] func functional object that accepts two arguments of
      *  type index_t.
@@ -601,8 +624,7 @@ namespace GEO {
      *  core (default is 1).
      */
      void GEOGRAM_API parallel_for_slice(
-	 index_t from, index_t to, std::function<void(index_t, index_t)> func,
-	 index_t threads_per_core = 1
+         index_t from, index_t to, std::function<void(index_t, index_t)> func
      );
 
      /**

--- a/src/lib/geogram/delaunay/delaunay.cpp
+++ b/src/lib/geogram/delaunay/delaunay.cpp
@@ -209,7 +209,8 @@ namespace GEO {
         store_cicl_ = false;
         keep_infinite_ = false;
         nb_finite_cells_ = 0;
-	keep_regions_ = false;
+        keep_regions_ = false;
+        Numeric::random_reset();
     }
 
     Delaunay::~Delaunay() {

--- a/src/lib/geogram/delaunay/delaunay.cpp
+++ b/src/lib/geogram/delaunay/delaunay.cpp
@@ -283,11 +283,8 @@ namespace GEO {
                 neighbors_.resize_array(i, default_nb_neighbors_, false);
             }
         }
-        parallel_for(
-	    0, nb_vertices(),
-	    [this](index_t i) { store_neighbors_CB(i); },
-	    1, true
-        );
+        auto toRun = [this](index_t i) { store_neighbors_CB(i); };
+        tbb_parallel_for(0, nb_vertices(), std::move(toRun));
     }
 
     void Delaunay::get_neighbors_internal(

--- a/src/lib/geogram/mesh/mesh_distance.cpp
+++ b/src/lib/geogram/mesh/mesh_distance.cpp
@@ -50,7 +50,10 @@
 #include <geogram/basic/process.h>
 #include <geogram/basic/stopwatch.h>
 
+#include <tbb/parallel_for.h>
+
 #include <algorithm>
+#include <atomic>
 
 namespace {
 
@@ -64,10 +67,10 @@ namespace {
      *  runs multiple instances of this class
      *  (one per core).
      */
-    class DistanceThread : public Thread {
+    class DistanceBody {
     public:
         /**
-         * \brief Constructs a new DistanceThread
+         * \brief Constructs a new DistanceBody
          * \details This DistanceThread will compute the distances
          *  between a batch of points and an axis-aligned bounding box
          *  tree.
@@ -79,53 +82,35 @@ namespace {
          * \param[in] points_stride number of doubles between two
          *  consecutive points
          */
-        DistanceThread(
-            const MeshFacetsAABB& AABB,
-            index_t from, index_t to,
+        DistanceBody(
+            const MeshFacetsAABB& AABB, std::atomic<double>& result,
             const double* points_ptr, index_t points_stride = 3
         ) :
             AABB_(AABB),
-            from_(from),
-            to_(to),
-            max_sq_dist_(0.0),
+            result_(result),
             points_ptr_(points_ptr),
             points_stride_(points_stride) {
         }
 
-        /**
-         * \brief Runs the thread.
-         * \details Computes the distances for the batch of points associated
-         *  with this thread.
-         */
-	void run() override {
-            for(index_t v = from_; v < to_; v++) {
-                // TODO: optimization
-                // if we know that the points are spatially
-                // sorted, then we can use AABB_.squared_distance_with_hint()
+        void operator()(const tbb::blocked_range<index_t>& range) const {
+            double max = 0.0;
+            for (auto i = range.begin(); i != range.end(); ++i) {
                 double sq_dist = AABB_.squared_distance(
                     *reinterpret_cast<const vec3*>(
-                        points_ptr_ + v * points_stride_
-                    )
+                        points_ptr_ + i * points_stride_
+                        )
                 );
-                max_sq_dist_ = std::max(
-                    max_sq_dist_, sq_dist
-                );
+                max = std::max(max, sq_dist);
             }
-        }
-
-        /**
-         * \brief Gets the computed max squared distance.
-         * \return the maximum squared distance computed so far
-         */
-        double max_squared_distance() const {
-            return max_sq_dist_;
+            auto expected = result_.load();
+            while (expected < max) {
+                result_.compare_exchange_weak(expected, max);
+            }
         }
 
     private:
         const MeshFacetsAABB& AABB_;
-        index_t from_;
-        index_t to_;
-        double max_sq_dist_;
+        std::atomic<double>& result_;
         const double* points_ptr_;
         index_t points_stride_;
     };
@@ -150,31 +135,11 @@ namespace {
         index_t points_stride = 3
     ) {
         SystemStopwatch W;
-        TypedThreadGroup<DistanceThread> threads;
-        index_t nb_threads = Process::maximum_concurrent_threads();
-        index_t batch_size = nb_points / nb_threads;
-        index_t cur = 0;
-        index_t remaining = nb_points;
-        for(index_t i = 0; i < nb_threads; i++) {
-            index_t this_batch_size = batch_size;
-            if(i == nb_threads - 1) {
-                this_batch_size = remaining;
-            }
-            threads.push_back(
-                new DistanceThread(
-                    AABB,
-                    cur, cur + this_batch_size,
-                    points_ptr, points_stride
-                )
-            );
-            cur += this_batch_size;
-            remaining -= this_batch_size;
-        }
-        geo_assert(remaining == 0);
-        Process::run_threads(threads);
-        for(index_t t = 0; t < threads.size(); t++) {
-            result = std::max(result, threads[t]->max_squared_distance());
-        }
+        std::atomic<double> max_sq_dist_atomic(0.);
+        DistanceBody body(AABB, max_sq_dist_atomic, points_ptr, points_stride);
+        tbb::parallel_for(tbb::blocked_range<index_t>(0, nb_points), body);
+        result = max_sq_dist_atomic;
+
         double elapsed = W.elapsed_user_time();
         if(elapsed == 0.0) {
             Logger::out("AABB")

--- a/src/lib/geogram/mesh/mesh_remesh.cpp
+++ b/src/lib/geogram/mesh/mesh_remesh.cpp
@@ -145,7 +145,6 @@ namespace GEO {
         bool multi_nerve = CmdLine::get_arg_bool("remesh:multi_nerve");
 
         Logger::out("Remesh") << "Computing RVD..." << std::endl;
-
         CVT.compute_surface(&M_out, multi_nerve);
         if(CmdLine::get_arg_bool("dbg:save_ANN_histo")) {
             Logger::out("ANN")

--- a/src/lib/geogram/mesh/mesh_reorder.cpp
+++ b/src/lib/geogram/mesh/mesh_reorder.cpp
@@ -54,6 +54,8 @@
 #include <geogram/basic/algorithm.h>
 #include <geogram/bibliography/bibliography.h>
 
+#include <tbb/parallel_for.h>
+
 #include <random>
 
 namespace {
@@ -709,8 +711,9 @@ namespace {
 
     /**
      * \brief Generic class for sorting arbitrary elements in
-     *  Hilbert and Morton orders in 3d.
-     * \details The implementation is inspired by:
+     *  Hilbert and Morton orders in 3d using tbb.
+     * \details The implementation is inspired by tbb::parallel_sort and the 
+     *  old non-tbb geogram version, which was in turn inspired by:
      *  - Christophe Delage and Olivier Devillers. Spatial Sorting.
      *   In CGAL User and Reference Manual. CGAL Editorial Board,
      *   3.9 edition, 2011
@@ -725,51 +728,166 @@ namespace {
      */
     template <template <int COORD, bool UP, class MESH> class CMP, class MESH>
     struct HilbertSort3d {
+        // tbb range class to allow for parallel_for with changing comparator.
+        class Range {
+        public:
+            Range(const MESH& M, vector<index_t>::iterator begin,
+                  vector<index_t>::iterator end) 
+                :M(M), begin(begin), end(end), phase(0), position(0)
+            {}
 
-        /**
-         * \brief Low-level recursive spatial sorting function
-         * \details This function is recursive
-         * \param[in] M the mesh in which the elements reside
-         * \param[in] begin an iterator that points to the
-         *  first element of the sequence
-         * \param[in] end an iterator that points one position past the
-         *  last element of the sequence
-         * \param[in] limit subsequences smaller than limit are left unsorted
-         * \tparam COORDX the first coordinate, can be 0,1 or 2. The second
-         *  and third coordinates are COORDX+1 modulo 3 and COORDX+2 modulo 3
-         *  respectively
-         * \tparam UPX whether ordering along the first coordinate
-         *  is direct or inverse
-         * \tparam UPY whether ordering along the second coordinate
-         *  is direct or inverse
-         * \tparam UPZ whether ordering along the third coordinate
-         *  is direct or inverse
-         */
-        template <int COORDX, bool UPX, bool UPY, bool UPZ, class IT>
-        static void sort(
-            const MESH& M, IT begin, IT end, index_t limit = 1
-        ) {
-            const int COORDY = (COORDX + 1) % 3, COORDZ = (COORDY + 1) % 3;
-            if(end - begin <= signed_index_t(limit)) {
-                return;
+            bool empty() const { return begin == end; }
+
+            bool is_runnable() const { return end - begin > 1; }
+
+            bool is_divisible() const { return end - begin >= 256; }
+
+            vector<index_t>::iterator compare_and_sort() {
+                auto middle = begin + (end - begin) / 2;
+                switch (COORDX * 2 + UPX) {
+                case 0:
+                {
+                    CMP<0, false, MESH> cmp(M);
+                    std::nth_element(begin, middle, end, cmp);
+                    break;
+                }
+                case 1:
+                {
+                    CMP<0, true, MESH> cmp(M);
+                    std::nth_element(begin, middle, end, cmp);
+                    break;
+                }
+                case 2:
+                {
+                    CMP<1, false, MESH> cmp(M);
+                    std::nth_element(begin, middle, end, cmp);
+                    break;
+                }
+                case 3:
+                {
+                    CMP<1, true, MESH> cmp(M);
+                    std::nth_element(begin, middle, end, cmp);
+                    break;
+                }
+                case 4:
+                {
+                    CMP<2, false, MESH> cmp(M);
+                    std::nth_element(begin, middle, end, cmp);
+                    break;
+                }
+                case 5:
+                {
+                    CMP<2, true, MESH> cmp(M);
+                    std::nth_element(begin, middle, end, cmp);
+                    break;
+                }
+                default:
+                    geo_assert_not_reached;
+                }
+                return middle;
             }
-            IT m0 = begin, m8 = end;
-            IT m4 = reorder_split(m0, m8, CMP<COORDX, UPX, MESH>(M));
-            IT m2 = reorder_split(m0, m4, CMP<COORDY, UPY, MESH>(M));
-            IT m1 = reorder_split(m0, m2, CMP<COORDZ, UPZ, MESH>(M));
-            IT m3 = reorder_split(m2, m4, CMP<COORDZ, !UPZ, MESH>(M));
-            IT m6 = reorder_split(m4, m8, CMP<COORDY, !UPY, MESH>(M));
-            IT m5 = reorder_split(m4, m6, CMP<COORDZ, UPZ, MESH>(M));
-            IT m7 = reorder_split(m6, m8, CMP<COORDZ, !UPZ, MESH>(M));
-            sort<COORDZ, UPZ, UPX, UPY>(M, m0, m1);
-            sort<COORDY, UPY, UPZ, UPX>(M, m1, m2);
-            sort<COORDY, UPY, UPZ, UPX>(M, m2, m3);
-            sort<COORDX, UPX, !UPY, !UPZ>(M, m3, m4);
-            sort<COORDX, UPX, !UPY, !UPZ>(M, m4, m5);
-            sort<COORDY, !UPY, UPZ, !UPX>(M, m5, m6);
-            sort<COORDY, !UPY, UPZ, !UPX>(M, m6, m7);
-            sort<COORDZ, !UPZ, !UPX, UPY>(M, m7, m8);
-        }
+
+            Range(Range& r, tbb::split) : Range(r) {
+                auto middle = compare_and_sort();
+
+                advanceCoord();
+                ++phase;
+                position <<= 1;
+                position |= 1;
+                begin = middle;
+                UPX = !UPX;
+                updateForPhase3();
+
+                r.advanceCoord();
+                ++r.phase;
+                r.position <<= 1;
+                r.end = middle;
+                r.updateForPhase3();
+            }
+
+        private:
+            void advanceCoord() {
+                COORDX = (COORDX + 1) % 3;
+                auto temp = UPX;
+                UPX = UPY;
+                UPY = UPZ;
+                UPZ = temp;
+            }
+
+            void retreatCoord() {
+                COORDX = (COORDX + 2) % 3;
+                auto temp = UPX;
+                UPX = UPZ;
+                UPZ = UPY;
+                UPY = temp;
+            }
+
+            void updateForPhase3() {
+                if (phase < 3) {
+                    return;
+                }
+                geo_assert(phase == 3);
+                phase = 0;
+                switch (position) {
+                case 0:
+                    retreatCoord();
+                    break;
+                case 1:
+                    UPX = !UPX; // We negated it in the last split, 
+                                // so undo that.
+                    advanceCoord();
+                    break;
+                case 2:
+                    UPZ = !UPZ;
+                    advanceCoord();
+                    break;
+                case 3:
+                    UPX = !UPX;
+                    UPY = !UPY; // We want to negate it.
+                    break;
+                case 4:
+                    UPZ = !UPZ;
+                    break;
+                case 5:
+                    advanceCoord();
+                    break;
+                case 6:
+                    UPX = !UPX;
+                    UPZ = !UPZ;
+                    advanceCoord();
+                    break;
+                case 7:
+                    UPY = !UPY;
+                    retreatCoord();
+                    break;
+                default:
+                    geo_assert_not_reached;
+                }
+                position = 0;
+            }
+
+            int COORDX = 0;
+            bool UPX = false;
+            bool UPY = false;
+            bool UPZ = false;
+            int phase; // Our splitting technique only repeats every 3 splits.
+            int position; // Position relative to the last phase 0.
+
+            const MESH& M;
+            vector<index_t>::iterator begin;
+            vector<index_t>::iterator end;
+        };
+
+        // tbb body class, to be called on the range.
+        struct Body {
+            void operator()(Range& r) const
+            {
+                while (r.is_runnable()) {
+                    Range splitResult(r, tbb::split{});
+                    operator()(splitResult);
+                }
+            }
+        };
 
         /**
          * \brief Sorts a sequence of elements spatially.
@@ -788,8 +906,7 @@ namespace {
             vector<index_t>::iterator b,
             vector<index_t>::iterator e,
             index_t limit = 1
-        ) :
-            M_(M)
+        ) 
         {
             geo_debug_assert(e > b);
 	    geo_cite_with_info(
@@ -799,69 +916,16 @@ namespace {
                 " template in the spatial sort package of CGAL"
 	    );
 
+            Range range(M, b, e);
+
             // If the sequence is smaller than the limit, skip it
-            if(index_t(e - b) <= limit) {
+            if (index_t(e - b) <= limit) {
                 return;
             }
 
-            // If the sequence is smaller than 1024, use sequential sorting
-            if(index_t(e - b) < 1024) {
-                sort<0, false, false, false>(M_, b, e);
-                return;
-            }
-
-            // Parallel sorting (2 then 4 then 8 sorts in parallel)
-
-// Unfortunately we cannot access consts for template arguments in lambdas in all
-// compilers (gcc is OK but not MSVC) so I'm using (ugly) macros here...
-
-#          define COORDX 0
-#          define COORDY 1
-#          define COORDZ 2
-#          define UPX false
-#          define UPY false
-#          define UPZ false
-
-            m0_ = b;
-            m8_ = e;
-            m4_ = reorder_split(m0_, m8_, CMP<COORDX, UPX, MESH>(M));
-
-
-	    parallel(
-		[this]() { m2_ = reorder_split(m0_, m4_, CMP<COORDY,  UPY, MESH>(M_)); },
-		[this]() { m6_ = reorder_split(m4_, m8_, CMP<COORDY, !UPY, MESH>(M_)); }
-	    );
-
-	    parallel(
-		[this]() { m1_ = reorder_split(m0_, m2_, CMP<COORDZ,  UPZ, MESH>(M_)); },
-		[this]() { m3_ = reorder_split(m2_, m4_, CMP<COORDZ, !UPZ, MESH>(M_)); },
-		[this]() { m5_ = reorder_split(m4_, m6_, CMP<COORDZ,  UPZ, MESH>(M_)); },
-		[this]() { m7_ = reorder_split(m6_, m8_, CMP<COORDZ, !UPZ, MESH>(M_)); }
-	    );
-
-	    parallel(
-		[this]() { sort<COORDZ,  UPZ,  UPX,  UPY>(M_, m0_, m1_); },
-		[this]() { sort<COORDY,  UPY,  UPZ,  UPX>(M_, m1_, m2_); },
-		[this]() { sort<COORDY,  UPY,  UPZ,  UPX>(M_, m2_, m3_); },
-		[this]() { sort<COORDX,  UPX, !UPY, !UPZ>(M_, m3_, m4_); },
-		[this]() { sort<COORDX,  UPX, !UPY, !UPZ>(M_, m4_, m5_); },
-		[this]() { sort<COORDY, !UPY,  UPZ, !UPX>(M_, m5_, m6_); },
-		[this]() { sort<COORDY, !UPY,  UPZ, !UPX>(M_, m6_, m7_); },
-		[this]() { sort<COORDZ, !UPZ, !UPX,  UPY>(M_, m7_, m8_); }
-	    );
-
-#          undef COORDX
-#          undef COORDY
-#          undef COORDZ
-#          undef UPX
-#          undef UPY
-#          undef UPZ
+            Range r(M, b, e);
+            tbb::parallel_for(range, Body{});
         }
-
-    private:
-        const MESH& M_;
-        vector<index_t>::iterator
-            m0_, m1_, m2_, m3_, m4_, m5_, m6_, m7_, m8_;
     };
 
     /************************************************************************/

--- a/src/lib/geogram/mesh/mesh_reorder.cpp
+++ b/src/lib/geogram/mesh/mesh_reorder.cpp
@@ -1272,9 +1272,7 @@ namespace GEO {
         //(random_shuffle is deprecated in C++17, and they call this
         // progess...)
         //std::random_shuffle(sorted_indices.begin(), sorted_indices.end());
-        std::random_device rng;
-        std::mt19937 urng(rng());
-        std::shuffle(sorted_indices.begin(), sorted_indices.end(), urng);
+         std::shuffle(sorted_indices.begin(), sorted_indices.end(), std::mt19937());
 
         compute_BRIO_order_recursive(
             nb_vertices, vertices,
@@ -1472,9 +1470,7 @@ namespace GEO {
         //(random_shuffle is deprecated in C++17, and they call this
         // progess...)
         // std::random_shuffle(b,e);
-        std::random_device rng;
-        std::mt19937 urng(rng());
-        std::shuffle(b,e, urng);
+        std::shuffle(b,e, std::mt19937());
 
 	PeriodicVertexMesh3d M(nb_vertices, vertices, stride, period);
 	HilbertSort3d<Hilbert_vcmp_periodic, PeriodicVertexMesh3d>(

--- a/src/lib/geogram/mesh/mesh_repair.h
+++ b/src/lib/geogram/mesh/mesh_repair.h
@@ -84,6 +84,8 @@ namespace GEO {
      *  Combine them with the 'bitwise or' (|) operator.
      * \param[in] colocate_epsilon tolerance used to colocate vertices
      *  (if #MESH_REPAIR_COLOCATE is set in mode).
+     * \param[in] colocate_use_tbb whether to use tbb to multithread colocating
+     *  vertices (if #MESH_REPAIR_COLOCATE is set in mode).
      */
     void GEOGRAM_API mesh_repair(
         Mesh& M,
@@ -165,6 +167,8 @@ namespace GEO {
      * \param[in] colocate_epsilon if the distance between two
      *  mesh vertices is smaller than colocate_epsilon, then they
      *  are colocated.
+     * \param[in] colocate_use_tbb if true, colocation is multithreaded
+     *  via tbb.
      */
     void GEOGRAM_API mesh_detect_colocated_vertices(
         const Mesh& M, vector<index_t>& v_colocated_index,

--- a/src/lib/geogram/points/colocate.cpp
+++ b/src/lib/geogram/points/colocate.cpp
@@ -242,11 +242,10 @@ namespace GEO {
             Colocate colocate_obj(NN, old2new, tolerance);
 	    
             if(CmdLine::get_arg_bool("sys:multithread")) {
-                parallel_for(
-		    0, nb_points,
-		    [&colocate_obj](index_t i){ colocate_obj.do_it(i); },
-		    1, true
-		);
+                tbb_parallel_for(
+                    0, nb_points,
+                    [&colocate_obj](index_t i){ colocate_obj.do_it(i); }
+                );
             } else {
                 for(index_t i = 0; i < nb_points; i++) {
                     colocate_obj.do_it(i);

--- a/src/lib/geogram/points/colocate.h
+++ b/src/lib/geogram/points/colocate.h
@@ -70,6 +70,8 @@ namespace GEO {
          *  points (set to dim if unspecified).
          * \param[in] nn_algo factory name for nearest neighbor search.
          * \return the number of unique points
+         * \param[in] use_tbb whether to use tbb to multithread the process.
+         * \return the number of unique points
          */
         index_t GEOGRAM_API colocate(
             const double* points,

--- a/src/lib/geogram/points/kd_tree.cpp
+++ b/src/lib/geogram/points/kd_tree.cpp
@@ -48,6 +48,8 @@
 #include <geogram/basic/process.h>
 #include <geogram/basic/algorithm.h>
 
+#include <tbb/parallel_for.h>
+
 namespace {
 
     using namespace GEO;
@@ -416,16 +418,7 @@ namespace GEO {
 /****************************************************************************/
     
     BalancedKdTree::BalancedKdTree(coord_index_t dim) :
-        KdTree(dim),
-        m0_(max_index_t()),
-        m1_(max_index_t()),
-        m2_(max_index_t()),
-        m3_(max_index_t()),
-        m4_(max_index_t()),
-        m5_(max_index_t()),
-        m6_(max_index_t()),
-        m7_(max_index_t()),
-        m8_(max_index_t()) {
+        KdTree(dim) {
     }
 
     BalancedKdTree::~BalancedKdTree() {
@@ -435,55 +428,50 @@ namespace GEO {
         index_t sz = max_node_index(1, 0, nb_points()) + 1;
         splitting_coord_.resize(sz);
         splitting_val_.resize(sz);
-	
-        // If there are more than 16*MAX_LEAF_SIZE (=256) points,
-        // create the tree in parallel
-        if(
-            nb_points() >= (16 * MAX_LEAF_SIZE) &&
-            Process::maximum_concurrent_threads() > 1
-        ) {
-            m0_ = 0;
-            m8_ = nb_points();
-            // Create the first level of the tree
-            m4_ = split_kd_node(1, m0_, m8_);
-	    
-            // Create the second level of the tree
-            //  (using two threads)
-	    parallel(
-		[this]() { m2_ = split_kd_node(2, m0_, m4_); },
-		[this]() { m6_ = split_kd_node(3, m4_, m8_); }
-	    );
-	    
-            // Create the third level of the tree
-            //  (using four threads)
-	    parallel(
-		[this]() { m1_ = split_kd_node(4, m0_, m2_); },
-		[this]() { m3_ = split_kd_node(5, m2_, m4_); },
-		[this]() { m5_ = split_kd_node(6, m4_, m6_); },
-		[this]() { m7_ = split_kd_node(7, m6_, m8_); }		
-	    );
+        // A tbb Range class can allow us to use tbb for multithreading.
+        class Range {
+        public:
+            // Root node is number 1.
+            // This is because "children at 2*n and 2*n+1" does not
+            // work with 0 !!
 
-            // Create the fourth level of the tree
-            //  (using eight threads)
-	    parallel(
-		[this]() { create_kd_tree_recursive(8 , m0_, m1_); },
-		[this]() { create_kd_tree_recursive(9 , m1_, m2_); },
-		[this]() { create_kd_tree_recursive(10, m2_, m3_); },
-		[this]() { create_kd_tree_recursive(11, m3_, m4_); },
-		[this]() { create_kd_tree_recursive(12, m4_, m5_); },
-		[this]() { create_kd_tree_recursive(13, m5_, m6_); },
-		[this]() { create_kd_tree_recursive(14, m6_, m7_); },
-		[this]() { create_kd_tree_recursive(15, m7_, m8_); }		
-	    );
-	    
-        } else {
-            create_kd_tree_recursive(1, 0, nb_points());
-        }
-	
-	// Root node is number 1.
-	// This is because "children at 2*n and 2*n+1" does not
-	// work with 0 !!
-	return 1;
+            Range(BalancedKdTree& tree, index_t b, index_t e) 
+                : tree(tree), b(b), e(e), node_index(1) {}
+
+            bool empty() const { return b == e; }
+            bool is_divisible() const { return e - b >= 4 * MAX_LEAF_SIZE; }
+
+            Range(Range& r, tbb::split) : Range(r) {
+                auto middle = tree.split_kd_node(node_index, b, e);
+
+                r.e = middle;
+                r.node_index <<= 1;
+
+                b = middle;
+                node_index <<= 1;
+                node_index |= 1;
+            }
+
+            void create_single_threaded() const {
+                tree.create_kd_tree_recursive(node_index, b, e);
+            }
+
+        private:
+            BalancedKdTree& tree;
+            index_t b;
+            index_t e;
+            index_t node_index;
+        };
+        
+        struct Body {
+            void operator()(const Range& r) const {
+                r.create_single_threaded();
+            }
+        };
+
+        tbb::parallel_for(Range(*this, 0, nb_points()), Body{});
+        
+        return 1;
     }
 
     index_t BalancedKdTree::split_kd_node(

--- a/src/lib/geogram/points/kd_tree.h
+++ b/src/lib/geogram/points/kd_tree.h
@@ -548,11 +548,6 @@ namespace GEO {
 	 * \brief One per node, splitting coordinate value.
 	 */
         vector<double> splitting_val_;
-
-	/**
-	 * \brief Indices for multithreaded tree construction.
-	 */
-        index_t m0_, m1_, m2_, m3_, m4_, m5_, m6_, m7_, m8_;
     };
 
     /*********************************************************************/

--- a/src/lib/geogram/voronoi/CVT.cpp
+++ b/src/lib/geogram/voronoi/CVT.cpp
@@ -133,13 +133,14 @@ namespace GEO {
         points_.resize(dimension_ * nb_points);
     }
 
-    void CentroidalVoronoiTesselation::Lloyd_iterations(index_t nb_iter) {
+    void CentroidalVoronoiTesselation::Lloyd_iterations(
+        index_t nb_iter, bool safe_mode) {
         index_t nb_points = index_t(points_.size() / dimension_);
 
         vector<double> mg;
         vector<double> m;
 
-        RVD_->set_check_SR(false);
+        RVD_->set_check_SR(safe_mode);
 
         if(progress_ != nullptr) {
             progress_->reset(nb_iter);

--- a/src/lib/geogram/voronoi/CVT.h
+++ b/src/lib/geogram/voronoi/CVT.h
@@ -162,15 +162,18 @@ namespace GEO {
          *  the point set before calling Newton_iterations().
          * \param[in] nb_iter number of iterations
          * \param[in] safe_mode a flag that determines whether to run this
-         * function in a way that avoids potential errors in the algorithm when
-         * a point has many neighbors.  If set to false, the potential errors
-         * will typically be fairly minor (and thus still produce a suitable
-         * input for Newton_iterations()), but will be dependent on the number
-         * of threads used (and thus may pose issues for reproducibility across
-         * different machines); they may also be somewhat more significant in
-         * extreme cases.
+         *  function in a way that avoids potential errors in the algorithm when
+         *  a point has many neighbors.  If set to false, the potential errors
+         *  will typically be fairly minor (and thus still produce a suitable
+         *  input for Newton_iterations()), but will be dependent on the number
+         *  of threads used (and thus may pose issues for reproducibility across
+         *  different machines); they may also be somewhat more significant in
+         *  extreme cases.
+         * \param[in] safe_mode a flag that determines whether to run this
+         *  function using tbb for multithreading
          */
-        virtual void Lloyd_iterations(index_t nb_iter, bool safe_mode = false);
+        virtual void Lloyd_iterations(index_t nb_iter, 
+                                      bool safe_mode = true);
 
         /**
          * \brief Relaxes the points with Newton-Lloyd's algorithm.
@@ -291,6 +294,8 @@ namespace GEO {
          * \param[in] x current value of the variables
          * \param[out] f current value of the objective function
          * \param[out] g gradient of the objective function
+
+
          */
         static void funcgrad_CB(
             index_t n, double* x, double& f, double* g

--- a/src/lib/geogram/voronoi/CVT.h
+++ b/src/lib/geogram/voronoi/CVT.h
@@ -161,8 +161,16 @@ namespace GEO {
          *  a call to compute_initial_sampling() to regularize
          *  the point set before calling Newton_iterations().
          * \param[in] nb_iter number of iterations
+         * \param[in] safe_mode a flag that determines whether to run this
+         * function in a way that avoids potential errors in the algorithm when
+         * a point has many neighbors.  If set to false, the potential errors
+         * will typically be fairly minor (and thus still produce a suitable
+         * input for Newton_iterations()), but will be dependent on the number
+         * of threads used (and thus may pose issues for reproducibility across
+         * different machines); they may also be somewhat more significant in
+         * extreme cases.
          */
-        virtual void Lloyd_iterations(index_t nb_iter);
+        virtual void Lloyd_iterations(index_t nb_iter, bool safe_mode = false);
 
         /**
          * \brief Relaxes the points with Newton-Lloyd's algorithm.

--- a/src/lib/geogram/voronoi/RVD.cpp
+++ b/src/lib/geogram/voronoi/RVD.cpp
@@ -447,8 +447,8 @@ namespace {
                     part(t).master_g_ = &accu_g_;
                 }
                 accu_m_.clear();
-                accu_m_.reserve(3 * mesh_->facets.nb());
                 accu_g_.clear();
+                accu_m_.reserve(mesh_->facets.nb());
                 accu_g_.reserve(DIM * mesh_->facets.nb());
                 parallel_for(
                     0, nb_parts(),
@@ -602,8 +602,8 @@ namespace {
                     part(t).master_g_ = &accu_g_;
                 }
                 accu_m_.clear();
-                accu_m_.reserve(mesh_->cells.nb());
                 accu_g_.clear();
+                accu_m_.reserve(mesh_->cells.nb());
                 accu_g_.reserve(DIM * mesh_->cells.nb());
                 parallel_for(
                     0, nb_parts(),
@@ -909,8 +909,8 @@ namespace {
                     part(t).master_g_ = &accu_g_;
                 }
                 accu_f_.clear();
-                accu_f_.reserve(mesh_->facets.nb());
                 accu_g_.clear();
+                accu_f_.reserve(mesh_->facets.nb());
                 accu_g_.reserve(DIM * mesh_->facets.nb());
                 parallel_for(
                     0, nb_parts(),
@@ -1084,8 +1084,8 @@ namespace {
                     part(t).master_g_ = &accu_g_;
                 }
                 accu_f_.clear();
-                accu_f_.reserve(mesh_->cells.nb());
                 accu_g_.clear();
+                accu_f_.reserve(mesh_->cells.nb());
                 accu_g_.reserve(DIM * mesh_->cells.nb());
                 parallel_for(
                     0, nb_parts(),

--- a/src/lib/geogram/voronoi/RVD.cpp
+++ b/src/lib/geogram/voronoi/RVD.cpp
@@ -2585,7 +2585,9 @@ namespace {
             }
             index_t nb_parts_in = Process::maximum_concurrent_threads();
             if(nb_parts() != nb_parts_in) {
-                if(nb_parts_in == 1) {
+                if(false && nb_parts_in == 1) {
+                    // Codepath disabled to ensure deterministic results independently of the number of
+                    // threads used.
                     delete_threads();
                 } else {
                     vector<index_t> facet_ptr;

--- a/src/lib/geogram/voronoi/RVD.cpp
+++ b/src/lib/geogram/voronoi/RVD.cpp
@@ -59,8 +59,12 @@
 #include <geogram/basic/argused.h>
 #include <geogram/basic/algorithm.h>
 #include <geogram/bibliography/bibliography.h>
+
+#include <geogram/basic/disable_warnings.h>
 #include <tbb/concurrent_vector.h>
 #include <tbb/parallel_sort.h>
+#include <geogram/basic/enable_warnings.h>
+
 #include <cmath>
 #include <cassert>
 
@@ -483,7 +487,7 @@ namespace {
         /********************************************************************/
 
         /**
-         * \brief Implementation class for surfacic Lloyd relaxation.
+         * \brief Implementation class for volumetric Lloyd relaxation.
          * \details To be used as a template argument
          *    to RVD::for_each_volumetric_integration_simplex().
          * This version ignores the weights.
@@ -576,22 +580,132 @@ namespace {
             LOCKS& locks_;
         };
 
-	void compute_centroids_in_volume(double* mg, double* m) override {
+        /**
+         * \brief Implementation class for volumetric Lloyd relaxation.
+         * \details To be used as a template
+         *    argument to RVD::for_each_triangle().
+         * This version takes the weights into account.
+         *
+         * Computes for each RVD cell:
+         * - mg[v] (v's Voronoi cell's total area times centroid)
+         * - m[v]  (v's total area)
+         * \tparam LOCKS locking policy
+         *   (can be one of Process::SpinLockArray, NoLocks)
+         */
+        template <class LOCKS>
+        class ComputeCentroidsVolumicWeighted {
+        public:
+            /**
+             * \brief Constructs a ComputeCentroidsWeighted.
+             * \param[out] mg where to store the centroids
+             * \param[out] m where to store the masses
+             * \param[in] locks the array of locks
+             *  (or NoLocks in single thread mode)
+             */
+            ComputeCentroidsVolumicWeighted(
+                double* mg,
+                double* m,
+                tbb::concurrent_vector<std::pair<index_t, double>>* master_g,
+                tbb::concurrent_vector<std::pair<index_t, double>>* master_m,
+                LOCKS& locks
+            ) :
+                mg_(mg),
+                m_(m),
+                master_g_(master_g),
+                master_m_(master_m),
+                locks_(locks) {
+            }
+
+            /**
+             * \brief The callback called for each integration simplex.
+             * \param[in] v index of current center vertex
+             * \param[in] v_adj (unused here) is the index of the Voronoi cell
+             *  adjacent to t accros facet (\p v1, \p v2, \p v3) or
+             *  -1 if it does not exists
+             *  \param[in] t (unused here) is the index of the current
+             *   tetrahedron
+             *  \param[in] t_adj (unused here) is the index of the
+             *   tetrahedron adjacent to t accros facet (\p v1, \p v2, \p v3)
+             *   or -1 if it does not exists
+             * \param[in] p0 first vertex of current integration simplex
+             * \param[in] p1 second vertex of current integration simplex
+             * \param[in] p2 third vertex of current integration simplex
+             * \param[in] p3 fourth vertex of current integration simplex
+             */
+            void operator() (
+                index_t v, signed_index_t v_adj,
+                index_t t, signed_index_t t_adj,
+                const Vertex& v1,
+                const Vertex& v2,
+                const Vertex& v3,
+                const Vertex& v4
+            ) const {
+                geo_argused(v_adj);
+                geo_argused(t);
+                geo_argused(t_adj);
+                double cur_m;
+                double cur_Vg[DIM];
+                Geom::tetra_centroid(
+                    v1.point(), v2.point(), v3.point(), v4.point(),
+                    v1.weight(), v2.weight(), v3.weight(), v4.weight(),
+                    cur_Vg, cur_m, DIM
+                );
+                if (master_m_) {
+                    master_m_->emplace_back(v, cur_m);
+                    for(coord_index_t coord = 0; coord < DIM; coord++) {
+                        master_g_->emplace_back(v * DIM + coord, cur_Vg[coord]);
+                    }
+                } else {
+                    locks_.acquire_spinlock(v);
+                    m_[v] += cur_m;
+                    double* cur_mg_out = mg_ + v * DIM;
+                    for(coord_index_t coord = 0; coord < DIM; coord++) {
+                        cur_mg_out[coord] += cur_Vg[coord];
+                    }
+                    locks_.release_spinlock(v);
+                }
+            }
+
+        private:
+            double* mg_;
+            double* m_;
+            tbb::concurrent_vector<std::pair<index_t, double>> * master_g_;
+            tbb::concurrent_vector<std::pair<index_t, double>> * master_m_;
+            LOCKS& locks_;
+        };
+
+        void compute_centroids_in_volume(double* mg, double* m) override {
             create_threads();
             if(nb_parts() == 0) {
                 if(master_ != nullptr) {
-                    RVD_.for_each_tetrahedron(
-                        ComputeCentroidsVolumetric<Process::SpinLockArray>(
-                            mg, m, master_g_, master_m_, master_->spinlocks_
-                        )
-                    );
+                    if(has_weights_) {
+                        RVD_.for_each_tetrahedron(
+                            ComputeCentroidsVolumicWeighted<Process::SpinLockArray>(
+                                mg, m, master_g_, master_m_, master_->spinlocks_
+                            )
+                        );
+                    } else {
+                        RVD_.for_each_tetrahedron(
+                            ComputeCentroidsVolumetric<Process::SpinLockArray>(
+                                mg, m, master_g_, master_m_, master_->spinlocks_
+                            )
+                        );
+                    }
                 } else {
-                    NoLocks nolocks;
-                    RVD_.for_each_tetrahedron(
-                        ComputeCentroidsVolumetric<NoLocks>(
-                            mg, m, master_g_, master_m_, nolocks
-                        )
-                    );
+                    NoLocks nolocks;;
+                    if(has_weights_) {
+                        RVD_.for_each_tetrahedron(
+                            ComputeCentroidsVolumicWeighted<NoLocks>(
+                                mg, m, master_g_, master_m_, nolocks
+                            )
+                        );
+                    } else {
+                        RVD_.for_each_tetrahedron(
+                            ComputeCentroidsVolumetric<NoLocks>(
+                                mg, m, master_g_, master_m_, nolocks
+                            )
+                        );
+                    }
                 }
             } else {
                 thread_mode_ = MT_LLOYD;

--- a/src/lib/geogram/voronoi/RVD.cpp
+++ b/src/lib/geogram/voronoi/RVD.cpp
@@ -59,6 +59,10 @@
 #include <geogram/basic/argused.h>
 #include <geogram/basic/algorithm.h>
 #include <geogram/bibliography/bibliography.h>
+#include <tbb/concurrent_vector.h>
+#include <tbb/parallel_sort.h>
+#include <cmath>
+#include <cassert>
 
 /*
  * There are three levels of implementation:
@@ -69,6 +73,8 @@
  *
  * Warning: there are approx. 1000 lines of boring code ahead.
  */
+
+#define MAKE_KEY(x) std::make_pair(std::abs(x), std::signbit(x))
 
 namespace {
 
@@ -563,10 +569,14 @@ namespace {
                 const GenRestrictedVoronoiDiagram& RVD,
                 double& f,
                 double* g,
+                tbb::concurrent_vector<double> * master_f,
+                tbb::concurrent_vector<std::pair<index_t, double>> * master_g,
                 LOCKS& locks
             ) :
                 f_(f),
                 g_(g),
+                master_f_(master_f),
+                master_g_(master_g),
                 locks_(locks),
                 RVD_(RVD) {
             }
@@ -599,18 +609,29 @@ namespace {
                     cur_f += u2 * (u0 + u1 + u2);
                 }
 
-                f_ += t_area * cur_f / 6.0;
+                if (master_f_) {
+                    master_f_->push_back(t_area * cur_f / 6.0);
+                    for(index_t c = 0; c < DIM; c++) {
+                        double Gc = (1.0 / 3.0) * (p1[c] + p2[c] + p3[c]);
+                        double val = (2.0 * t_area) * (p0[c] - Gc);
+                        master_g_->emplace_back(v * DIM + c, val);
+                    }
+                } else {
+                    f_ += t_area * cur_f / 6.0;
 
-                locks_.acquire_spinlock(v);
-                for(index_t c = 0; c < DIM; c++) {
-                    double Gc = (1.0 / 3.0) * (p1[c] + p2[c] + p3[c]);
-                    g_[DIM * v + c] += (2.0 * t_area) * (p0[c] - Gc);
+                    locks_.acquire_spinlock(v);
+                    for(index_t c = 0; c < DIM; c++) {
+                        double Gc = (1.0 / 3.0) * (p1[c] + p2[c] + p3[c]);
+                        g_[DIM * v + c] += (2.0 * t_area) * (p0[c] - Gc);
+                    }
+                    locks_.release_spinlock(v);
                 }
-                locks_.release_spinlock(v);
             }
 
             double& f_;
             double* g_;
+            tbb::concurrent_vector<double> * master_f_;
+            tbb::concurrent_vector<std::pair<index_t, double>> * master_g_;
             LOCKS& locks_;
             const GenRestrictedVoronoiDiagram& RVD_;
         };
@@ -643,10 +664,14 @@ namespace {
                 const GenRestrictedVoronoiDiagram& RVD,
                 double& f,
                 double* g,
+                tbb::concurrent_vector<double> * master_f,
+                tbb::concurrent_vector<std::pair<index_t, double>> * master_g,
                 LOCKS& locks
             ) :
                 f_(f),
                 g_(g),
+                master_f_(master_f),
+                master_g_(master_g),
                 locks_(locks),
                 RVD_(RVD) {
             }
@@ -708,23 +733,39 @@ namespace {
                 cur_f += (alpha[2] + rho[1]) * dotprod_21;  // 2 1
                 cur_f += (alpha[2] + rho[2]) * dotprod_22;  // 2 2
 
-                f_ += t_area * cur_f / 30.0;
-                double* g_out = g_ + v * DIM;
-                locks_.acquire_spinlock(v);
-                for(index_t c = 0; c < DIM; c++) {
-                    g_out[c] += (t_area / 6.0) * (
-                        4.0 * Sp * p0[c] - (
-                            alpha[0] * p1[c] +
-                            alpha[1] * p2[c] +
-                            alpha[2] * p3[c]
-                        )
-                    );
+                if (master_f_) {
+                    master_f_->push_back(t_area * cur_f / 30.0);
+                    for(index_t c = 0; c < DIM; c++) {
+                        double val = (t_area / 6.0) * (
+                            4.0 * Sp * p0[c] - (
+                                alpha[0] * p1[c] +
+                                alpha[1] * p2[c] +
+                                alpha[2] * p3[c]
+                            )
+                        );
+                        master_g_->emplace_back(v * DIM + c, val);
+                    }
+                } else {
+                    f_ += t_area * cur_f / 30.0;
+                    double* g_out = g_ + v * DIM;
+                    locks_.acquire_spinlock(v);
+                    for(index_t c = 0; c < DIM; c++) {
+                        g_out[c] += (t_area / 6.0) * (
+                            4.0 * Sp * p0[c] - (
+                                alpha[0] * p1[c] +
+                                alpha[1] * p2[c] +
+                                alpha[2] * p3[c]
+                            )
+                        );
+                    }
+                    locks_.release_spinlock(v);
                 }
-                locks_.release_spinlock(v);
             }
 
             double& f_;
             double* g_;
+            tbb::concurrent_vector<double> * master_f_;
+            tbb::concurrent_vector<std::pair<index_t, double>> * master_g_;
             LOCKS& locks_;
             const GenRestrictedVoronoiDiagram& RVD_;
         };
@@ -736,13 +777,13 @@ namespace {
                     if(has_weights_) {
                         RVD_.for_each_triangle(
                             ComputeCVTFuncGradWeighted<Process::SpinLockArray>(
-                                RVD_, f, g, master_->spinlocks_
+                                RVD_, f, g, master_f_, master_g_, master_->spinlocks_
                             )
                         );
                     } else {
                         RVD_.for_each_triangle(
                             ComputeCVTFuncGrad<Process::SpinLockArray>(
-                                RVD_, f, g, master_->spinlocks_
+                                RVD_, f, g, master_f_, master_g_, master_->spinlocks_
                             )
                         );
                     }
@@ -751,13 +792,13 @@ namespace {
                     if(has_weights_) {
                         RVD_.for_each_triangle(
                             ComputeCVTFuncGradWeighted<NoLocks>(
-                                RVD_, f, g, nolocks
+                                RVD_, f, g, master_f_, master_g_, nolocks
                             )
                         );
                     } else {
                         RVD_.for_each_triangle(
                             ComputeCVTFuncGrad<NoLocks>(
-                                RVD_, f, g, nolocks
+                                RVD_, f, g, master_f_, master_g_, nolocks
                             )
                         );
                     }
@@ -768,13 +809,34 @@ namespace {
                 spinlocks_.resize(delaunay_->nb_vertices());
                 for(index_t t = 0; t < nb_parts(); t++) {
                     part(t).funcval_ = 0.0;
+                    part(t).master_f_ = &accu_f_;
+                    part(t).master_g_ = &accu_g_;
                 }
+                accu_f_.clear();
+                accu_f_.reserve(mesh_->facets.nb());
+                accu_g_.clear();
+                accu_g_.reserve(DIM * mesh_->facets.nb());
                 parallel_for(
                     0, nb_parts(),
 		    [this](index_t i) { run_thread(i); }
                 );
-                for(index_t t = 0; t < nb_parts(); t++) {
-                    f += part(t).funcval_;
+                // sort accu_f_ and accu_g_ by abs value, then sum elements
+                tbb::parallel_sort(accu_f_.begin(), accu_f_.end(), [](double x, double y) {
+                    return MAKE_KEY(x) < MAKE_KEY(y);
+                });
+                tbb::parallel_sort(accu_g_.begin(), accu_g_.end(), [](
+                    const std::pair<index_t, double> &x,
+                    const std::pair<index_t, double> &y
+                    )
+                {
+                    return std::make_pair(x.first, MAKE_KEY(x.second))
+                         < std::make_pair(y.first, MAKE_KEY(y.second));
+                });
+                for (double x : accu_f_) {
+                    f += x;
+                }
+                for (const auto &kv : accu_g_) {
+                    g[kv.first] += kv.second;
                 }
             }
         }
@@ -811,10 +873,14 @@ namespace {
                 const GenRestrictedVoronoiDiagram& RVD,
                 double& f,
                 double* g,
+                tbb::concurrent_vector<double> * master_f,
+                tbb::concurrent_vector<std::pair<index_t, double>> * master_g,
                 LOCKS& locks
             ) :
                 f_(f),
                 g_(g),
+                master_f_(master_f),
+                master_g_(master_g),
                 locks_(locks),
                 RVD_(RVD) {
             }
@@ -861,22 +927,37 @@ namespace {
                     fi += (Uc * Vc + Vc * Wc + Wc * Uc);
                 }
                 fi *= (mi / 10.0);
-                f_ += fi;
 
-                // gi = 2*mi(p0 - 1/4(p0 + p1 + p2 + p3))
-                double* g_out = g_ + v * DIM;
-                locks_.acquire_spinlock(v);
-                for(coord_index_t c = 0; c < DIM; ++c) {
-                    g_out[c] += 2.0 * mi * (
-                        0.75 * p0[c]
-                        - 0.25 * p1[c] - 0.25 * p2[c] - 0.25 * p3[c]
-                    );
+                if (master_f_) {
+                    master_f_->push_back(fi);
+                    // gi = 2*mi(p0 - 1/4(p0 + p1 + p2 + p3))
+                    for(coord_index_t c = 0; c < DIM; ++c) {
+                        double val = 2.0 * mi * (
+                            0.75 * p0[c]
+                            - 0.25 * p1[c] - 0.25 * p2[c] - 0.25 * p3[c]
+                        );
+                        master_g_->emplace_back(v * DIM + c, val);
+                    }
+                } else {
+                    f_ += fi;
+
+                    // gi = 2*mi(p0 - 1/4(p0 + p1 + p2 + p3))
+                    double* g_out = g_ + v * DIM;
+                    locks_.acquire_spinlock(v);
+                    for(coord_index_t c = 0; c < DIM; ++c) {
+                        g_out[c] += 2.0 * mi * (
+                            0.75 * p0[c]
+                            - 0.25 * p1[c] - 0.25 * p2[c] - 0.25 * p3[c]
+                        );
+                    }
+                    locks_.release_spinlock(v);
                 }
-                locks_.release_spinlock(v);
             }
 
             double& f_;
             double* g_;
+            tbb::concurrent_vector<double> * master_f_;
+            tbb::concurrent_vector<std::pair<index_t, double>> * master_g_;
             LOCKS& locks_;
             const GenRestrictedVoronoiDiagram& RVD_;
         };
@@ -887,14 +968,14 @@ namespace {
                 if(master_ != nullptr) {
                     RVD_.for_each_volumetric_integration_simplex(
                         ComputeCVTFuncGradVolumetric<Process::SpinLockArray>(
-                            RVD_, f, g, master_->spinlocks_
+                            RVD_, f, g, master_f_, master_g_, master_->spinlocks_
                         )
                     );
                 } else {
                     NoLocks nolocks;
                     RVD_.for_each_volumetric_integration_simplex(
                         ComputeCVTFuncGradVolumetric<NoLocks>(
-                            RVD_, f, g, nolocks
+                            RVD_, f, g, master_f_, master_g_, nolocks
                         )
                     );
                 }
@@ -904,13 +985,34 @@ namespace {
                 spinlocks_.resize(delaunay_->nb_vertices());
                 for(index_t t = 0; t < nb_parts(); t++) {
                     part(t).funcval_ = 0.0;
+                    part(t).master_f_ = &accu_f_;
+                    part(t).master_g_ = &accu_g_;
                 }
+                accu_f_.clear();
+                accu_f_.reserve(mesh_->facets.nb());
+                accu_g_.clear();
+                accu_g_.reserve(DIM * mesh_->facets.nb());
                 parallel_for(
                     0, nb_parts(),
 		    [this](index_t i) { run_thread(i); }
                 );
-                for(index_t t = 0; t < nb_parts(); t++) {
-                    f += part(t).funcval_;
+                // sort accu_f_ and accu_g_ by abs value, then sum elements
+                tbb::parallel_sort(accu_f_.begin(), accu_f_.end(), [](double x, double y) {
+                    return MAKE_KEY(x) < MAKE_KEY(y);
+                });
+                tbb::parallel_sort(accu_g_.begin(), accu_g_.end(), [](
+                    const std::pair<index_t, double> &x,
+                    const std::pair<index_t, double> &y
+                    )
+                {
+                    return std::make_pair(x.first, MAKE_KEY(x.second))
+                         < std::make_pair(y.first, MAKE_KEY(y.second));
+                });
+                for (double x : accu_f_) {
+                    f += x;
+                }
+                for (const auto &kv : accu_g_) {
+                    g[kv.first] += kv.second;
                 }
             }
         }
@@ -1642,6 +1744,7 @@ namespace {
                 } break;
                 case MT_INT_SMPLX:
                 {
+                    assert(false); // not deterministic for now
                     T.compute_integration_simplex_func_grad(
                         T.funcval_, arg_vectors_, simplex_func_
                     );
@@ -2515,9 +2618,14 @@ namespace {
         double* arg_vectors_;
         double* arg_scalars_;
 
+        tbb::concurrent_vector<double> accu_f_;
+        tbb::concurrent_vector<std::pair<index_t, double>> accu_g_;
+
         // Variables for 'slaves' in multithreading mode
         thisclass* master_;
         double funcval_;  // Newton mode: function value
+        tbb::concurrent_vector<double> * master_f_ = nullptr;
+        tbb::concurrent_vector<std::pair<index_t, double>> * master_g_ = nullptr;
 
     protected:
         /**

--- a/src/lib/geogram/voronoi/RVD.cpp
+++ b/src/lib/geogram/voronoi/RVD.cpp
@@ -275,10 +275,14 @@ namespace {
             ComputeCentroids(
                 double* mg,
                 double* m,
+                tbb::concurrent_vector<std::pair<index_t, double>>* master_g,
+                tbb::concurrent_vector<std::pair<index_t, double>>* master_m,
                 LOCKS& locks
             ) :
                 mg_(mg),
                 m_(m),
+                master_g_(master_g),
+                master_m_(master_m),
                 locks_(locks) {
             }
 
@@ -297,19 +301,29 @@ namespace {
             ) const {
                 double cur_m = Geom::triangle_area(p1, p2, p3, DIM);
                 double s = cur_m / 3.0;
-                locks_.acquire_spinlock(v);
-                m_[v] += cur_m;
-                double* cur_mg_out = mg_ + v * DIM;
-                for(coord_index_t coord = 0; coord < DIM; coord++) {
-                    cur_mg_out[coord] +=
-                        s * (p1[coord] + p2[coord] + p3[coord]);
+                if (master_m_) {
+                    master_m_->emplace_back(v, cur_m);
+                    for(coord_index_t coord = 0; coord < DIM; coord++) {
+                        double val = s * (p1[coord] + p2[coord] + p3[coord]);
+                        master_g_->emplace_back(v * DIM + coord, val);
+                    }
+                } else {
+                    locks_.acquire_spinlock(v);
+                    m_[v] += cur_m;
+                    double* cur_mg_out = mg_ + v * DIM;
+                    for(coord_index_t coord = 0; coord < DIM; coord++) {
+                        cur_mg_out[coord] +=
+                            s * (p1[coord] + p2[coord] + p3[coord]);
+                    }
+                    locks_.release_spinlock(v);
                 }
-                locks_.release_spinlock(v);
             }
 
         private:
             double* mg_;
             double* m_;
+            tbb::concurrent_vector<std::pair<index_t, double>> * master_g_;
+            tbb::concurrent_vector<std::pair<index_t, double>> * master_m_;
             LOCKS& locks_;
         };
 
@@ -338,10 +352,14 @@ namespace {
             ComputeCentroidsWeighted(
                 double* mg,
                 double* m,
+                tbb::concurrent_vector<std::pair<index_t, double>>* master_g,
+                tbb::concurrent_vector<std::pair<index_t, double>>* master_m,
                 LOCKS& locks
             ) :
                 mg_(mg),
                 m_(m),
+                master_g_(master_g),
+                master_m_(master_m),
                 locks_(locks) {
             }
 
@@ -365,18 +383,27 @@ namespace {
                     v1.weight(), v2.weight(), v3.weight(),
                     cur_Vg, cur_m, DIM
                 );
-                locks_.acquire_spinlock(v);
-                m_[v] += cur_m;
-                double* cur_mg_out = mg_ + v * DIM;
-                for(coord_index_t coord = 0; coord < DIM; coord++) {
-                    cur_mg_out[coord] += cur_Vg[coord];
+                if (master_m_) {
+                    master_m_->emplace_back(v, cur_m);
+                    for(coord_index_t coord = 0; coord < DIM; coord++) {
+                        master_g_->emplace_back(v * DIM + coord, cur_Vg[coord]);
+                    }
+                } else {
+                    locks_.acquire_spinlock(v);
+                    m_[v] += cur_m;
+                    double* cur_mg_out = mg_ + v * DIM;
+                    for(coord_index_t coord = 0; coord < DIM; coord++) {
+                        cur_mg_out[coord] += cur_Vg[coord];
+                    }
+                    locks_.release_spinlock(v);
                 }
-                locks_.release_spinlock(v);
             }
 
         private:
             double* mg_;
             double* m_;
+            tbb::concurrent_vector<std::pair<index_t, double>> * master_g_;
+            tbb::concurrent_vector<std::pair<index_t, double>> * master_m_;
             LOCKS& locks_;
         };
 
@@ -387,13 +414,13 @@ namespace {
                     if(has_weights_) {
                         RVD_.for_each_triangle(
                             ComputeCentroidsWeighted<Process::SpinLockArray>(
-                                mg, m, master_->spinlocks_
+                                mg, m, master_g_, master_m_, master_->spinlocks_
                             )
                         );
                     } else {
                         RVD_.for_each_triangle(
                             ComputeCentroids<Process::SpinLockArray>(
-                                mg, m, master_->spinlocks_
+                                mg, m, master_g_, master_m_, master_->spinlocks_
                             )
                         );
                     }
@@ -402,12 +429,12 @@ namespace {
                     if(has_weights_) {
                         RVD_.for_each_triangle(
                             ComputeCentroidsWeighted<NoLocks>(
-                                mg, m, nolocks
+                                mg, m, master_g_, master_m_, nolocks
                             )
                         );
                     } else {
                         RVD_.for_each_triangle(
-                            ComputeCentroids<NoLocks>(mg, m, nolocks)
+                            ComputeCentroids<NoLocks>(mg, m, master_g_, master_m_, nolocks)
                         );
                     }
                 }
@@ -415,11 +442,41 @@ namespace {
                 thread_mode_ = MT_LLOYD;
                 arg_vectors_ = mg;
                 arg_scalars_ = m;
-                spinlocks_.resize(delaunay_->nb_vertices());
+                for(index_t t = 0; t < nb_parts(); t++) {
+                    part(t).master_m_ = &accu_m_;
+                    part(t).master_g_ = &accu_g_;
+                }
+                accu_m_.clear();
+                accu_m_.reserve(mesh_->facets.nb());
+                accu_g_.clear();
+                accu_g_.reserve(DIM * mesh_->facets.nb());
                 parallel_for(
                     0, nb_parts(),
 		    [this](index_t i) { run_thread(i); }
                 );
+                // sort accu_m_ and accu_g_ by abs value, then sum elements
+                tbb::parallel_sort(accu_m_.begin(), accu_m_.end(), [](
+                    const std::pair<index_t, double> &x,
+                    const std::pair<index_t, double> &y
+                    )
+                {
+                    return std::make_pair(x.first, MAKE_KEY(x.second))
+                         < std::make_pair(y.first, MAKE_KEY(y.second));
+                });
+                tbb::parallel_sort(accu_g_.begin(), accu_g_.end(), [](
+                    const std::pair<index_t, double> &x,
+                    const std::pair<index_t, double> &y
+                    )
+                {
+                    return std::make_pair(x.first, MAKE_KEY(x.second))
+                         < std::make_pair(y.first, MAKE_KEY(y.second));
+                });
+                for (const auto &kv : accu_m_) {
+                    m[kv.first] += kv.second;
+                }
+                for (const auto &kv : accu_g_) {
+                    mg[kv.first] += kv.second;
+                }
             }
         }
 
@@ -444,19 +501,20 @@ namespace {
              * \brief Constructs a ComputeCentroidsVolumetric.
              * \param[out] mg where to store the centroids
              * \param[out] m where to store the masses
-             * \param[in] delaunay the Delaunay triangulation
              * \param[in] locks the array of locks
              *  (or NoLocks in single thread mode)
              */
             ComputeCentroidsVolumetric(
                 double* mg,
                 double* m,
-                const Delaunay* delaunay,
+                tbb::concurrent_vector<std::pair<index_t, double>>* master_g,
+                tbb::concurrent_vector<std::pair<index_t, double>>* master_m,
                 LOCKS& locks
             ) :
                 mg_(mg),
                 m_(m),
-                delaunay_(delaunay),
+                master_g_(master_g),
+                master_m_(master_m),
                 locks_(locks) {
             }
 
@@ -491,21 +549,30 @@ namespace {
                     p0, p1, p2, p3
                 );
                 double s = cur_m / 4.0;
-                locks_.acquire_spinlock(v);
-                m_[v] += cur_m;
-                double* cur_mg_out = mg_ + v * DIM;
-                for(coord_index_t coord = 0; coord < DIM; coord++) {
-                    cur_mg_out[coord] += s * (
-                        p0[coord] + p1[coord] + p2[coord] + p3[coord]
-                    );
+                if (master_m_) {
+                    master_m_->emplace_back(v, cur_m);
+                    for(coord_index_t coord = 0; coord < DIM; coord++) {
+                        double val = s * (p0[coord] + p1[coord] + p2[coord] + p3[coord]);
+                        master_g_->emplace_back(v * DIM + coord, val);
+                    }
+                } else {
+                    locks_.acquire_spinlock(v);
+                    m_[v] += cur_m;
+                    double* cur_mg_out = mg_ + v * DIM;
+                    for(coord_index_t coord = 0; coord < DIM; coord++) {
+                        cur_mg_out[coord] += s * (
+                            p0[coord] + p1[coord] + p2[coord] + p3[coord]
+                        );
+                    }
+                    locks_.release_spinlock(v);
                 }
-                locks_.release_spinlock(v);
             }
 
         private:
             double* mg_;
             double* m_;
-            const Delaunay* delaunay_;
+            tbb::concurrent_vector<std::pair<index_t, double>> * master_g_;
+            tbb::concurrent_vector<std::pair<index_t, double>> * master_m_;
             LOCKS& locks_;
         };
 
@@ -515,14 +582,14 @@ namespace {
                 if(master_ != nullptr) {
                     RVD_.for_each_tetrahedron(
                         ComputeCentroidsVolumetric<Process::SpinLockArray>(
-                            mg, m, RVD_.delaunay(), master_->spinlocks_
+                            mg, m, master_g_, master_m_, master_->spinlocks_
                         )
                     );
                 } else {
                     NoLocks nolocks;
                     RVD_.for_each_tetrahedron(
                         ComputeCentroidsVolumetric<NoLocks>(
-                            mg, m, RVD_.delaunay(), nolocks
+                            mg, m, master_g_, master_m_, nolocks
                         )
                     );
                 }
@@ -530,11 +597,41 @@ namespace {
                 thread_mode_ = MT_LLOYD;
                 arg_vectors_ = mg;
                 arg_scalars_ = m;
-                spinlocks_.resize(delaunay_->nb_vertices());
+                for(index_t t = 0; t < nb_parts(); t++) {
+                    part(t).master_m_ = &accu_m_;
+                    part(t).master_g_ = &accu_g_;
+                }
+                accu_m_.clear();
+                accu_m_.reserve(mesh_->facets.nb());
+                accu_g_.clear();
+                accu_g_.reserve(DIM * mesh_->facets.nb());
                 parallel_for(
                     0, nb_parts(),
 		    [this](index_t i) { run_thread(i); }
                 );
+                // sort accu_m_ and accu_g_ by abs value, then sum elements
+                tbb::parallel_sort(accu_m_.begin(), accu_m_.end(), [](
+                    const std::pair<index_t, double> &x,
+                    const std::pair<index_t, double> &y
+                    )
+                {
+                    return std::make_pair(x.first, MAKE_KEY(x.second))
+                         < std::make_pair(y.first, MAKE_KEY(y.second));
+                });
+                tbb::parallel_sort(accu_g_.begin(), accu_g_.end(), [](
+                    const std::pair<index_t, double> &x,
+                    const std::pair<index_t, double> &y
+                    )
+                {
+                    return std::make_pair(x.first, MAKE_KEY(x.second))
+                         < std::make_pair(y.first, MAKE_KEY(y.second));
+                });
+                for (const auto &kv : accu_m_) {
+                    m[kv.first] += kv.second;
+                }
+                for (const auto &kv : accu_g_) {
+                    mg[kv.first] += kv.second;
+                }
             }
         }
 
@@ -806,7 +903,6 @@ namespace {
             } else {
                 thread_mode_ = MT_NEWTON;
                 arg_vectors_ = g;
-                spinlocks_.resize(delaunay_->nb_vertices());
                 for(index_t t = 0; t < nb_parts(); t++) {
                     part(t).funcval_ = 0.0;
                     part(t).master_f_ = &accu_f_;
@@ -982,7 +1078,6 @@ namespace {
             } else {
                 thread_mode_ = MT_NEWTON;
                 arg_vectors_ = g;
-                spinlocks_.resize(delaunay_->nb_vertices());
                 for(index_t t = 0; t < nb_parts(); t++) {
                     part(t).funcval_ = 0.0;
                     part(t).master_f_ = &accu_f_;
@@ -2620,12 +2715,14 @@ namespace {
 
         tbb::concurrent_vector<double> accu_f_;
         tbb::concurrent_vector<std::pair<index_t, double>> accu_g_;
+        tbb::concurrent_vector<std::pair<index_t, double>> accu_m_;
 
         // Variables for 'slaves' in multithreading mode
         thisclass* master_;
         double funcval_;  // Newton mode: function value
         tbb::concurrent_vector<double> * master_f_ = nullptr;
         tbb::concurrent_vector<std::pair<index_t, double>> * master_g_ = nullptr;
+        tbb::concurrent_vector<std::pair<index_t, double>> * master_m_ = nullptr;
 
     protected:
         /**

--- a/src/lib/geogram/voronoi/RVD.cpp
+++ b/src/lib/geogram/voronoi/RVD.cpp
@@ -194,6 +194,7 @@ namespace {
             arg_scalars_ = nullptr;
             thread_mode_ = MT_NONE;
             nb_triangles_ = 0;
+            set_use_tbb(false);
         }
 
 	void set_delaunay(Delaunay* delaunay) override {
@@ -403,6 +404,7 @@ namespace {
                 }
             }
 
+
         private:
             double* mg_;
             double* m_;
@@ -414,7 +416,20 @@ namespace {
 	void compute_centroids_on_surface(double* mg, double* m) override {
             create_threads();
             if(nb_parts() == 0) {
-                if(master_ != nullptr) {
+                if (use_tbb_) {
+                    // When using tbb, we want to use the master-based version
+                    // of ComputeCentroids or ComputeCentroidsWeighted, but with
+                    // *this as the master in question.
+                    arg_vectors_ = mg;
+                    arg_scalars_ = m;
+                    master_m_ = &accu_m_;
+                    master_g_ = &accu_g_;
+                    accu_m_.clear();
+                    accu_g_.clear();
+                    accu_m_.reserve(mesh_->facets.nb());
+                    accu_g_.reserve(DIM * mesh_->facets.nb());
+                }
+                if(master_ != nullptr || use_tbb_) {
                     if(has_weights_) {
                         RVD_.for_each_triangle(
                             ComputeCentroidsWeighted<Process::SpinLockArray>(
@@ -446,7 +461,7 @@ namespace {
                 thread_mode_ = MT_LLOYD;
                 arg_vectors_ = mg;
                 arg_scalars_ = m;
-                for(index_t t = 0; t < nb_parts(); t++) {
+                for (index_t t = 0; t < nb_parts(); t++) {
                     part(t).master_m_ = &accu_m_;
                     part(t).master_g_ = &accu_g_;
                 }
@@ -458,6 +473,8 @@ namespace {
                     0, nb_parts(),
 		    [this](index_t i) { run_thread(i); }
                 );
+            }
+            if (nb_parts() != 0 || use_tbb_) {
                 // sort accu_m_ and accu_g_ by abs value, then sum elements
                 tbb::parallel_sort(accu_m_.begin(), accu_m_.end(), [](
                     const std::pair<index_t, double> &x,
@@ -677,7 +694,19 @@ namespace {
         void compute_centroids_in_volume(double* mg, double* m) override {
             create_threads();
             if(nb_parts() == 0) {
-                if(master_ != nullptr) {
+                if (use_tbb_) {
+                    // When using tbb, we want to use the master-based version
+                    // of our action, but with *this as the master in question.
+                    arg_vectors_ = mg;
+                    arg_scalars_ = m;
+                    master_m_ = &accu_m_;
+                    master_g_ = &accu_g_;
+                    accu_m_.clear();
+                    accu_g_.clear();
+                    accu_m_.reserve(mesh_->facets.nb());
+                    accu_g_.reserve(DIM * mesh_->facets.nb());
+                }
+                if(master_ != nullptr || use_tbb_) {
                     if(has_weights_) {
                         RVD_.for_each_tetrahedron(
                             ComputeCentroidsVolumicWeighted<Process::SpinLockArray>(
@@ -711,7 +740,7 @@ namespace {
                 thread_mode_ = MT_LLOYD;
                 arg_vectors_ = mg;
                 arg_scalars_ = m;
-                for(index_t t = 0; t < nb_parts(); t++) {
+                for (index_t t = 0; t < nb_parts(); t++) {
                     part(t).master_m_ = &accu_m_;
                     part(t).master_g_ = &accu_g_;
                 }
@@ -723,6 +752,8 @@ namespace {
                     0, nb_parts(),
 		    [this](index_t i) { run_thread(i); }
                 );
+            }
+            if (nb_parts() != 0 || use_tbb_) {
                 // sort accu_m_ and accu_g_ by abs value, then sum elements
                 tbb::parallel_sort(accu_m_.begin(), accu_m_.end(), [](
                     const std::pair<index_t, double> &x,
@@ -984,7 +1015,19 @@ namespace {
 	void compute_CVT_func_grad_on_surface(double& f, double* g) override {
             create_threads();
             if(nb_parts() == 0) {
-                if(master_ != nullptr) {
+                if (use_tbb_) {
+                    // When using tbb, we want to use the master-based version
+                    // of our action, but with *this as the master in question.
+                    arg_vectors_ = g;
+                    funcval_ = 0.0;
+                    master_f_ = &accu_f_;
+                    master_g_ = &accu_g_;
+                    accu_f_.clear();
+                    accu_g_.clear();
+                    accu_f_.reserve(mesh_->facets.nb());
+                    accu_g_.reserve(DIM * mesh_->facets.nb());
+                }
+                if(master_ != nullptr || use_tbb_) {
                     if(has_weights_) {
                         RVD_.for_each_triangle(
                             ComputeCVTFuncGradWeighted<Process::SpinLockArray>(
@@ -1030,6 +1073,8 @@ namespace {
                     0, nb_parts(),
 		    [this](index_t i) { run_thread(i); }
                 );
+            }
+            if (nb_parts() != 0 || use_tbb_) {
                 // sort accu_f_ and accu_g_ by abs value, then sum elements
                 tbb::parallel_sort(accu_f_.begin(), accu_f_.end(), [](double x, double y) {
                     return MAKE_KEY(x) < MAKE_KEY(y);
@@ -1175,7 +1220,19 @@ namespace {
 	void compute_CVT_func_grad_in_volume(double& f, double* g) override {
             create_threads();
             if(nb_parts() == 0) {
-                if(master_ != nullptr) {
+                if (use_tbb_) {
+                    // When using tbb, we want to use the master-based version
+                    // of our action, but with *this as the master in question.
+                    arg_vectors_ = g;
+                    funcval_ = 0.0;
+                    master_f_ = &accu_f_;
+                    master_g_ = &accu_g_;
+                    accu_f_.clear();
+                    accu_g_.clear();
+                    accu_f_.reserve(mesh_->facets.nb());
+                    accu_g_.reserve(DIM * mesh_->facets.nb());
+                }
+                if(master_ != nullptr || use_tbb_) {
                     RVD_.for_each_volumetric_integration_simplex(
                         ComputeCVTFuncGradVolumetric<Process::SpinLockArray>(
                             RVD_, f, g, master_f_, master_g_, master_->spinlocks_
@@ -1205,6 +1262,8 @@ namespace {
                     0, nb_parts(),
 		    [this](index_t i) { run_thread(i); }
                 );
+            }
+            if (nb_parts() != 0 || use_tbb_) {
                 // sort accu_f_ and accu_g_ by abs value, then sum elements
                 tbb::parallel_sort(accu_f_.begin(), accu_f_.end(), [](double x, double y) {
                     return MAKE_KEY(x) < MAKE_KEY(y);
@@ -1241,14 +1300,18 @@ namespace {
              * \brief Constructs a ComputeCVTFuncGradIntegrationSimplex.
              * \param[in] RVD the Restricted Voronoi Diagram
              * \param[in] F the IntegrationSimplex
+             * \param[in] multithread whether this may be used from multiple
+                threads simultaneously.
              */
             ComputeCVTFuncGradIntegrationSimplex(
                 const GenRestrictedVoronoiDiagram& RVD,
-                IntegrationSimplex* F
+                IntegrationSimplex* F,
+                bool multithread
             ) :
                 f_(0.0),
                 RVD_(RVD),
-                simplex_func_(F) {
+                simplex_func_(F),
+                multithread_(multithread) {
                 simplex_func_->reset_thread_local_storage();
             }
 
@@ -1265,9 +1328,15 @@ namespace {
                 const Vertex& v2,
                 const Vertex& v3
             ) {
-                f_ += simplex_func_->eval(
+                auto res = simplex_func_->eval(
                     i,v1,v2,v3,RVD_.current_facet()
                 );
+                if (multithread_) {
+                    accu_f_.push_back(res);
+                }
+                else {
+                    f_ += res;
+                }
             }
 
             /**
@@ -1294,16 +1363,35 @@ namespace {
             ) {
                 geo_argused(v_adj);
                 geo_argused(t_adj);
-                f_ += simplex_func_->eval(
+                auto res = simplex_func_->eval(
                     v,v1,v2,v3,t,index_t(t_adj),index_t(v_adj)
                 );
+                if (multithread_) {
+                    accu_f_.push_back(res);
+                }
+                else {
+                    f_ += res;
+                }
             }
 
             /**
-             * \brief Gets the function value.
+             * \brief Gets the function value.  Once called, this object ceases
+             *  to be multithread-safe (though simultaneously using the 
+             *  underlying IntegrationSimplex from multiple instances of this 
+             *  class remains ok).
              * \return The function value accumulated so far.
              */
-            double f() const {
+            double f() {
+                if (multithread_) {
+                    tbb::parallel_sort(accu_f_.begin(), accu_f_.end(), 
+                            [](double x, double y) {
+                        return MAKE_KEY(x) < MAKE_KEY(y);
+                    });
+                    for (double x : accu_f_) {
+                        f_ += x;
+                    }
+                    multithread_ = false;
+                }
                 return f_;
             }
 
@@ -1311,6 +1399,8 @@ namespace {
             double f_;
             const GenRestrictedVoronoiDiagram& RVD_;
             IntegrationSimplex* simplex_func_;
+            bool multithread_;
+            tbb::concurrent_vector<double> accu_f_;
         };
 
 	void compute_integration_simplex_func_grad(
@@ -1326,7 +1416,9 @@ namespace {
                         g
                     );
                 }
-                ComputeCVTFuncGradIntegrationSimplex C(RVD_,F);
+                ComputeCVTFuncGradIntegrationSimplex C(
+                    RVD_, F, use_tbb_
+                );
                 bool sym = RVD_.symbolic();
                 RVD_.set_symbolic(true);
                 if(F->volumetric()) {
@@ -1374,57 +1466,12 @@ namespace {
 
         /********************************************************************/
 
-        /**
-         * \brief Adapter class used internally to implement for_each_polygon()
-         * \details Gets the current triangle from the RVD and passes it back
-	 *  to the callback. It is needed because GenericRVD::for_each_polygon()
-	 *  does not pass the current triangle.
-         */
-	// TODO: pass it through all the callbacks, because it is ridiculous:
-	// we pass it through the first levels, then throw it, then retrieve it
-	// (see GenRVD)
-        class PolygonCallbackAction {
-        public:
-            /**
-             * \brief PolygonCallbackAction constructor
-             * \param[in] RVD a pointer to the restricted Voronoi diagram
-	     * \param[in] callback a pointer to the PolygonCallback
-             */
-            PolygonCallbackAction(
-		GenRestrictedVoronoiDiagram& RVD,
-		GEO::RVDPolygonCallback& callback
-	    ) :
-		RVD_(RVD),
-		callback_(callback) {
-            }
-
-            /**
-             * \brief Callback called for each polygon.
-             * \details Routes the callback to the wrapped user action class.
-             * \param[in] v index of current Delaunay seed
-             * \param[in] P intersection between current mesh facet
-             *  and the Voronoi cell of \p v
-             */
-            void operator() (
-                index_t v,
-                const GEOGen::Polygon& P
-            ) const {
-		callback_(v, RVD_.current_facet(), P);
-            }
-
-        protected:
-	    GenRestrictedVoronoiDiagram& RVD_;
-	    GEO::RVDPolygonCallback& callback_;
-        };
-
-
         virtual void compute_with_polygon_callback(
 	    GEO::RVDPolygonCallback& polygon_callback
         ) {
             create_threads();
             if(nb_parts() == 0) {
-		PolygonCallbackAction action(RVD_,polygon_callback);
-		RVD_.for_each_polygon(action);
+                RVD_.for_each_polygon(polygon_callback);
             } else {
                 for(index_t t = 0; t < nb_parts(); t++) {
                     part(t).RVD_.set_symbolic(RVD_.symbolic());
@@ -1495,10 +1542,10 @@ namespace {
             BuildRVD(
                 const GenRestrictedVoronoiDiagram& RVD_in,
                 BUILDER& builder
-            ) :
-                RVD(RVD_in),
+            ) :                
                 builder_(builder),
                 current_facet_(-1) {
+                geo_argused(RVD_in), // For backward compatibility only.
                 builder_.begin_surface();
             }
 
@@ -1521,9 +1568,9 @@ namespace {
              */
             void operator() (
                 index_t v,
+                index_t f,
                 const typename GenRestrictedVoronoiDiagram::Polygon& P
             ) {
-                index_t f = RVD.current_facet();
                 if(signed_index_t(f) != current_facet_) {
                     if(current_facet_ != -1) {
                         builder_.end_reference_facet();
@@ -1540,7 +1587,6 @@ namespace {
             }
 
         private:
-            const GenRestrictedVoronoiDiagram& RVD;
             BUILDER& builder_;
             signed_index_t current_facet_;
         };
@@ -1764,6 +1810,8 @@ namespace {
         ) override {
             bool sym = RVD_.symbolic();
             RVD_.set_symbolic(true);
+            bool old_use_tbb = use_tbb_;
+            set_use_tbb(false);
             if(volumetric_) {
                 if(dim == 0) {
                     dim = dimension();
@@ -1863,6 +1911,7 @@ namespace {
                 );
             }
             RVD_.set_symbolic(sym);
+            set_use_tbb(old_use_tbb);
             M.show_stats("RVD");
         }
 
@@ -1887,49 +1936,54 @@ namespace {
 
         /********************************************************************/
 
-	void for_each_polygon(
-	    GEO::RVDPolygonCallback& callback,
-	    bool symbolic,
-	    bool connected_comp_priority,
-	    bool parallel
-	) override {
-	    bool sym_backup = RVD_.symbolic();
-	    RVD_.set_symbolic(symbolic);
-	    RVD_.set_connected_components_priority(connected_comp_priority);
-	    callback.begin();
-	    if(parallel) {
-		compute_with_polygon_callback(callback);
-	    } else {
-		PolygonCallbackAction action(RVD_,callback);
-		RVD_.for_each_polygon(action);
-	    }
-	    callback.end();
-	    RVD_.set_symbolic(sym_backup);
-	    RVD_.set_connected_components_priority(false);
-	}
+        void for_each_polygon(
+            GEO::RVDPolygonCallback& callback,
+            bool symbolic,
+            bool connected_comp_priority,
+            bool parallel
+        ) override {
+            bool sym_backup = RVD_.symbolic();
+            RVD_.set_symbolic(symbolic);
+            RVD_.set_connected_components_priority(connected_comp_priority);
+            callback.begin();
+            if(parallel) {
+                compute_with_polygon_callback(callback);
+            } else {
+                auto old_use_tbb = use_tbb_;
+                set_use_tbb(false);
+                RVD_.for_each_polygon(callback);
+                set_use_tbb(old_use_tbb);
+            }
+            callback.end();
+            RVD_.set_symbolic(sym_backup);
+            RVD_.set_connected_components_priority(false);
+        }
 
         /********************************************************************/
 
-	void for_each_polyhedron(
-	    GEO::RVDPolyhedronCallback& callback,
-	    bool symbolic,
-	    bool connected_comp_priority,
-	    bool parallel
-	) override {
-	    bool sym_backup = RVD_.symbolic();
-	    RVD_.set_symbolic(symbolic);
-	    RVD_.set_connected_components_priority(connected_comp_priority);
-	    callback.set_dimension(RVD_.mesh()->vertices.dimension());
-	    callback.begin();
-	    if(parallel) {
-		compute_with_polyhedron_callback(callback);
-	    } else {
-		RVD_.for_each_polyhedron(callback);
-	    }
-	    callback.end();
-	    RVD_.set_symbolic(sym_backup);
-	    RVD_.set_connected_components_priority(false);
-	}
+        void for_each_polyhedron(
+            GEO::RVDPolyhedronCallback& callback,
+            bool symbolic,
+            bool connected_comp_priority,
+            bool parallel
+        ) override {
+            bool sym_backup = RVD_.symbolic();
+            RVD_.set_symbolic(symbolic);
+            RVD_.set_connected_components_priority(connected_comp_priority);
+            callback.set_dimension(RVD_.mesh()->vertices.dimension());
+            callback.begin();
+            if(parallel) {
+                compute_with_polyhedron_callback(callback);
+            } else {
+                auto old_use_tbb = use_tbb_;
+                set_use_tbb(false);
+                RVD_.for_each_polyhedron(callback);
+                set_use_tbb(old_use_tbb);
+            }
+            callback.end();
+            RVD_.set_symbolic(sym_backup);
+            RVD_.set_connected_components_priority(false);
+        }
 
         /********************************************************************/
 
@@ -2278,9 +2332,11 @@ namespace {
             /**
              * \brief The callback called for each restricted Voronoi cell.
              * \param[in] s1 index of current center vertex
+             * \param[in] facet current facet.  Not used.
              * \param[in] P current restricted Voronoi cell
              */
-            void operator() (index_t s1, const Polygon& P) {
+            void operator() (index_t s1, index_t facet, const Polygon& P) {
+                geo_argused(facet);
                 if(RVD_.connected_component_changed()) {
                     if(cur_seed_ != -1) {
                         end_connected_component();
@@ -2624,6 +2680,8 @@ namespace {
             const vector<bool>& seed_is_locked,
             MeshFacetsAABB* AABB
         ) override {
+            bool old_use_tbb = use_tbb_;
+            set_use_tbb(false);
             if(volumetric_) {
                 // For the moment, only simple mode is supported
                 simplices.clear();
@@ -2687,6 +2745,7 @@ namespace {
                     }
                 }
             }
+            set_use_tbb(old_use_tbb);
         }
 
 	void create_threads() override {
@@ -2695,6 +2754,30 @@ namespace {
             // TODO: create parts even if facets range is specified
             // (and subdivide facets range)
             if(is_slave_ || facets_begin_ != -1 || facets_end_ != -1) {
+                return;
+            }
+            if (use_tbb_) {
+                // We don't want to actually use worker objects, but we 
+                // sometimes call this to improve data locality, and that is
+                // relevant when using tbb, so we do that part of the thread 
+                // creation.  We do, however, do so in a way that is based on
+                // the mesh rather than the system.  We also set ranges for
+                // facets and tets, though since we're not using workers the
+                // range for each is simply the entirety of the mesh.
+                auto nb_parts_in = 
+                    static_cast<index_t>(std::log2(
+                        mesh_->facets.nb() + mesh_->cells.nb()
+                    ));
+                vector<index_t> facet_ptr;
+                vector<index_t> tet_ptr;
+                mesh_partition(
+                    *mesh_, MESH_PARTITION_HILBERT,
+                    facet_ptr, tet_ptr, nb_parts_in
+                );
+                set_facets_range(0, mesh_->facets.nb());
+                if (mesh_->cells.nb() != 0) {
+                    set_tetrahedra_range(0, mesh_->cells.nb());
+                }
                 return;
             }
             index_t nb_parts_in = Process::maximum_concurrent_threads();
@@ -2793,6 +2876,11 @@ namespace {
 	    return RVD_.point_allocator();
 	}
 
+        void set_use_tbb(bool x) override {
+            use_tbb_ = x;
+            RVD_.set_use_tbb(x);
+        }
+
 
     protected:
 
@@ -2839,6 +2927,8 @@ namespace {
         tbb::concurrent_vector<double> * master_f_ = nullptr;
         tbb::concurrent_vector<std::pair<index_t, double>> * master_g_ = nullptr;
         tbb::concurrent_vector<std::pair<index_t, double>> * master_m_ = nullptr;
+
+        bool use_tbb_ = true;
 
     protected:
         /**

--- a/src/lib/geogram/voronoi/RVD.cpp
+++ b/src/lib/geogram/voronoi/RVD.cpp
@@ -447,7 +447,7 @@ namespace {
                     part(t).master_g_ = &accu_g_;
                 }
                 accu_m_.clear();
-                accu_m_.reserve(mesh_->facets.nb());
+                accu_m_.reserve(3 * mesh_->facets.nb());
                 accu_g_.clear();
                 accu_g_.reserve(DIM * mesh_->facets.nb());
                 parallel_for(
@@ -602,9 +602,9 @@ namespace {
                     part(t).master_g_ = &accu_g_;
                 }
                 accu_m_.clear();
-                accu_m_.reserve(mesh_->facets.nb());
+                accu_m_.reserve(mesh_->cells.nb());
                 accu_g_.clear();
-                accu_g_.reserve(DIM * mesh_->facets.nb());
+                accu_g_.reserve(DIM * mesh_->cells.nb());
                 parallel_for(
                     0, nb_parts(),
 		    [this](index_t i) { run_thread(i); }
@@ -1084,9 +1084,9 @@ namespace {
                     part(t).master_g_ = &accu_g_;
                 }
                 accu_f_.clear();
-                accu_f_.reserve(mesh_->facets.nb());
+                accu_f_.reserve(mesh_->cells.nb());
                 accu_g_.clear();
-                accu_g_.reserve(DIM * mesh_->facets.nb());
+                accu_g_.reserve(DIM * mesh_->cells.nb());
                 parallel_for(
                     0, nb_parts(),
 		    [this](index_t i) { run_thread(i); }

--- a/src/lib/geogram/voronoi/RVD.h
+++ b/src/lib/geogram/voronoi/RVD.h
@@ -699,6 +699,15 @@ namespace GEO {
          */
         virtual GEOGen::PointAllocator* point_allocator() = 0;
 
+        /**
+         * \brief Determines whether this should use tbb for multithreading.
+         * \details We generally want to use tbb, but when running Lloyd
+         *  iterations not in safe mode, it can exacerbate reproducibility
+         *  issues.
+         * \param[in] x whether to use tbb
+         */
+        virtual void set_use_tbb(bool x) = 0;
+
     protected:
         /**
          * \brief This constructor is never called directly.

--- a/src/lib/geogram/voronoi/RVD.h
+++ b/src/lib/geogram/voronoi/RVD.h
@@ -13,7 +13,7 @@
  *  * Neither the name of the ALICE Project-Team nor the names of its
  *  contributors may be used to endorse or promote products derived from this
  *  software without specific prior written permission.
- * 
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -36,9 +36,9 @@
  *     http://www.loria.fr/~levy
  *
  *     ALICE Project
- *     LORIA, INRIA Lorraine, 
+ *     LORIA, INRIA Lorraine,
  *     Campus Scientifique, BP 239
- *     54506 VANDOEUVRE LES NANCY CEDEX 
+ *     54506 VANDOEUVRE LES NANCY CEDEX
  *     FRANCE
  *
  */
@@ -353,7 +353,7 @@ namespace GEO {
          */
         virtual void compute_integration_simplex_func_grad(
             double& f, double* g, IntegrationSimplex* F
-        )=0; 
+        )=0;
 
         /**
          * \brief Computes the projection of points onto the surface
@@ -421,9 +421,9 @@ namespace GEO {
 
 
         /**
-         * \brief Determines the operating mode of 
+         * \brief Determines the operating mode of
          *  compute_RDT().
-         * \details The flags can be combined with the 
+         * \details The flags can be combined with the
          *  'bitwise or' (|) operator.
          */
         enum RDTMode {
@@ -434,7 +434,7 @@ namespace GEO {
              */
             RDT_SEEDS_ALWAYS=0,
 
-            /** 
+            /**
              * \brief If set, the dual of the connected
              *  components of the restricted Voronoi diagram
              *  is computed.
@@ -451,7 +451,7 @@ namespace GEO {
             /**
              * \brief If set, the seeds are used whenever possible,
              *  i.e. whenever a restricted Voronoi cell has a single
-             *  connected component. 
+             *  connected component.
              */
             RDT_PREFER_SEEDS=4,
 
@@ -460,7 +460,7 @@ namespace GEO {
              *  seed and the restricted voronoi cell centroid the
              *  one that is nearest to the surface.
              *  Important: before using this
-             *  mode, the surface mesh needs to be reordered with 
+             *  mode, the surface mesh needs to be reordered with
              *  Morton order (see GEO::mesh_reorder).
              */
             RDT_SELECT_NEAREST=8,
@@ -469,7 +469,7 @@ namespace GEO {
              * \brief If set, then all the vertices are projected
              *  onto the surface.
              *  Important: before using this
-             *  mode, the surface mesh needs to be reordered with 
+             *  mode, the surface mesh needs to be reordered with
              *  Morton order (see GEO::mesh_reorder).
              */
             RDT_PROJECT_ON_SURFACE=16,
@@ -490,7 +490,7 @@ namespace GEO {
          *   (or tetrahedra vertices in volumetric mode)
          * \param[out] embedding the nD embedding of all vertices
          * \param[in] mode specifies how vertices geometry is
-         *  generated in surfacic mode (seeds or restricted Voronoi 
+         *  generated in surfacic mode (seeds or restricted Voronoi
          *  cells centroids)
          * \param[in] seed_is_locked if set, specifies which seed
          *  is locked (size = delaunay()->nb_vertices()). Locked
@@ -498,7 +498,7 @@ namespace GEO {
          *  centroid.
          * \param[in] AABB used if one of (RDT_RVC_PROJECT_ON_SURFACE,
          *   RDT_SELECT_NEAREST) is set in \p mode. If needed but not
-         *   specified, then a temporary one is created. 
+         *   specified, then a temporary one is created.
          */
         virtual void compute_RDT(
             vector<index_t>& simplices,
@@ -512,7 +512,7 @@ namespace GEO {
          * \brief Computes the restricted Delaunay triangulation.
          * \param[out] RDT the computed restricted Delaunay triangulation
          * \param[in] mode specifies how vertices geometry is
-         *  generated in surfacic mode (seeds or restricted Voronoi 
+         *  generated in surfacic mode (seeds or restricted Voronoi
          *  cells centroids)
          * \param[in] seed_is_locked if set, specifies which seed
          *  is locked (size = delaunay()->nb_vertices()). Locked
@@ -520,7 +520,7 @@ namespace GEO {
          *  centroid
          * \param[in] AABB used if one of (RDT_RVC_PROJECT_ON_SURFACE,
          *   RDT_SELECT_NEAREST) is set in \p mode. If needed but not
-         *   specified, then a temporary one is created. 
+         *   specified, then a temporary one is created.
          */
         void compute_RDT(
             Mesh& RDT,
@@ -559,8 +559,8 @@ namespace GEO {
          *  between a Voronoi cell and a mesh.
          * \param[in] i the index of the Voronoi cell
          * \param[in] M the mesh the Voronoi cell will be restricted to.
-         *   All its vertices should be of degree 3 (i.e., incident to 
-         *   exactly three facets). 
+         *   All its vertices should be of degree 3 (i.e., incident to
+         *   exactly three facets).
          *   In volumetric mode, the surfacic part of the mesh corresponds
          *   to the boundary of a volume. In surfacic mode, the mesh is
          *   a set of polygonal facets.
@@ -582,47 +582,47 @@ namespace GEO {
         ) = 0;
 
 
-	/**
-	 * \brief Invokes a user callback for each intersection polyhedron
-	 *  of the restricted Voronoi diagram (volumetric mode only).
-	 * \details Each intersection polyhedron is defined as the intersection
-	 *  between a Voronoi cell and a tetrahedron.
-	 * \param[in] callback the set of user callbacks, as an instance of a
-	 *  class derived from RVDPolyhedronCallback.
-	 * \param[in] symbolic if true, generate symbolic information in the
-	 *  vertices
-	 * \param[in] connected_comp_priority if true, generate polyhedron 
-	 *  intersections associated with the same Voronoi seed in order.
-	 * \param[in] parallel if true, tentatively parallelize computation.
-	 */
-	virtual void for_each_polyhedron(
-	    RVDPolyhedronCallback& callback,
-	    bool symbolic = true,
-	    bool connected_comp_priority = true,
-	    bool parallel = false
-	) = 0;
+        /**
+         * \brief Invokes a user callback for each intersection polyhedron
+         *  of the restricted Voronoi diagram (volumetric mode only).
+         * \details Each intersection polyhedron is defined as the intersection
+         *  between a Voronoi cell and a tetrahedron.
+         * \param[in] callback the set of user callbacks, as an instance of a
+         *  class derived from RVDPolyhedronCallback.
+         * \param[in] symbolic if true, generate symbolic information in the
+         *  vertices
+         * \param[in] connected_comp_priority if true, generate polyhedron
+         *  intersections associated with the same Voronoi seed in order.
+         * \param[in] parallel if true, tentatively parallelize computation.
+         */
+        virtual void for_each_polyhedron(
+            RVDPolyhedronCallback& callback,
+            bool symbolic = true,
+            bool connected_comp_priority = true,
+            bool parallel = false
+        ) = 0;
 
-	/**
-	 * \brief Invokes a user callback for each intersection polygon
-	 *  of the restricted Voronoi diagram (surfacic mode only).
-	 * \details Each intersection polygon is defined as the intersection
-	 *  between a Voronoi cell and a triangle.
-	 * \param[in] callback the set of user callbacks, as an instance of a
-	 *  class derived from RVDPolygonCallback.
-	 * \param[in] symbolic if true, generate symbolic information in the
-	 *  vertices
-	 * \param[in] connected_comp_priority if true, generate polyhedron 
-	 *  intersections associated with the same Voronoi seed in order.
-	 * \param[in] parallel if true, tentatively parallelize computation.
-	 */
-	virtual void for_each_polygon(
-	    RVDPolygonCallback& callback,
-	    bool symbolic = true,
-	    bool connected_comp_priority = true,
-	    bool parallel = false
-	) = 0;
-	
-	
+        /**
+         * \brief Invokes a user callback for each intersection polygon
+         *  of the restricted Voronoi diagram (surfacic mode only).
+         * \details Each intersection polygon is defined as the intersection
+         *  between a Voronoi cell and a triangle.
+         * \param[in] callback the set of user callbacks, as an instance of a
+         *  class derived from RVDPolygonCallback.
+         * \param[in] symbolic if true, generate symbolic information in the
+         *  vertices
+         * \param[in] connected_comp_priority if true, generate polyhedron
+         *  intersections associated with the same Voronoi seed in order.
+         * \param[in] parallel if true, tentatively parallelize computation.
+         */
+        virtual void for_each_polygon(
+            RVDPolygonCallback& callback,
+            bool symbolic = true,
+            bool connected_comp_priority = true,
+            bool parallel = false
+        ) = 0;
+
+
         /**
          * \brief Specifies whether the "radius of security"
          *  criterion should be enforced.
@@ -691,14 +691,14 @@ namespace GEO {
             return mesh_;
         }
 
-	/**
-	 * \brief Gets the PointAllocator.
-	 * \return a pointer to the PointAllocator, used
-	 *  to create the new vertices generated by 
-	 *  intersections.
-	 */
-	virtual GEOGen::PointAllocator* point_allocator() = 0;
-	
+        /**
+         * \brief Gets the PointAllocator.
+         * \return a pointer to the PointAllocator, used
+         *  to create the new vertices generated by
+         *  intersections.
+         */
+        virtual GEOGen::PointAllocator* point_allocator() = 0;
+
     protected:
         /**
          * \brief This constructor is never called directly.

--- a/src/lib/geogram/voronoi/RVD_callback.h
+++ b/src/lib/geogram/voronoi/RVD_callback.h
@@ -130,17 +130,17 @@ namespace GEO {
 	    return simplex_;
 	}
 
-	/**
-	 * \brief Sets the spinlocks array.
-	 * \details In multithreading mode, a spinlocks array can
-	 *  be used to manage concurrent accesses.
-	 * \param[in] spinlocks a pointer to the Process::SpinLockArray
-	 *  or nullptr if no spinlocks are used.
-	 */
-	void set_spinlocks(Process::SpinLockArray* spinlocks) {
-	    spinlocks_ = spinlocks;
-	}
-	
+        /**
+         * \brief Sets the spinlocks array.
+         * \details In multithreading mode, a spinlocks array can
+         *  be used to manage concurrent accesses.
+         * \param[in] spinlocks a pointer to the Process::SpinLockArray
+         *  or nullptr if no spinlocks are used.
+         */
+        void set_spinlocks(Process::SpinLockArray* spinlocks) {
+            spinlocks_ = spinlocks;
+        }
+
       protected:
 	index_t seed_;
 	index_t simplex_;
@@ -182,19 +182,18 @@ namespace GEO {
 	 */
 	virtual void end();
 
-	/**
-	 * \brief The default callback called for each polygon
-	 * \param[in] v index of current Delaunay seed
-	 * \param[in] t index of current mesh triangle
-	 * \param[in] C intersection between current mesh triangle
-	 *  and the Voronoi cell of \p v
-	 */
-	virtual void operator() (
-	    index_t v,
-	    index_t t,
-	    const GEOGen::Polygon& C
-	) const;
-
+        /**
+         * \brief The default callback called for each polygon
+         * \param[in] v index of current Delaunay seed
+         * \param[in] t index of current mesh triangle
+         * \param[in] C intersection between current mesh triangle
+         *  and the Voronoi cell of \p v
+         */
+        virtual void operator() (
+            index_t v,
+            index_t t,
+            const GEOGen::Polygon& C
+        ) const;
     };
     
     /***************************************************************/    
@@ -231,25 +230,23 @@ namespace GEO {
 	 */
 	virtual void end();
 
-	
-	/**
-	 * \brief The default callback called for each polyhedron
-	 * \details This default implementation routes the callback to the 
-	 *  begin_polyhedron_internal(), end_polyhedron_internal(), 
-	 *  begin_facet_internal(), end_facet_internal() and vertex_internal()
-	 *  functions (that in turn route the callbacks to their without 
-	 *  "_internal" counterparts).
-	 * \param[in] v index of current Delaunay seed
-	 * \param[in] t index of current mesh tetrahedron
-	 * \param[in] C intersection between current mesh tetrahedron
-	 *  and the Voronoi cell of \p v
-	 */
-	virtual void operator() (
-	    index_t v,
-	    index_t t,
-	    const GEOGen::ConvexCell& C
-	) const;
-	    
+        /**
+         * \brief The default callback called for each polyhedron
+         * \details This default implementation routes the callback to the 
+         *  begin_polyhedron_internal(), end_polyhedron_internal(), 
+         *  begin_facet_internal(), end_facet_internal() and vertex_internal()
+         *  functions (that in turn route the callbacks to their without 
+         *  "_internal" counterparts).
+         * \param[in] v index of current Delaunay seed
+         * \param[in] t index of current mesh tetrahedron
+         * \param[in] C intersection between current mesh tetrahedron
+         *  and the Voronoi cell of \p v
+         */
+        virtual void operator() (
+            index_t v,
+            index_t t,
+            const GEOGen::ConvexCell& C
+        ) const;
 
 	/**
 	 * \brief Called at the beginning of each intersection polyhedron.
@@ -332,61 +329,67 @@ namespace GEO {
 	    return facet_tet_;
 	}
 
-	/**
-	 * \brief Specifies whether internal tetrahedron facets should be
-	 *  removed.
-	 * \details If set, a single polyhedron is generated for each
-	 *  (connected component) of the restricted Voronoi cells. If not
-	 *  set (default), each tetrahedron-Voronoi cell intersection 
-	 *  generates a new polyhedron.
-	 * \param[in] x true if internal facets should be removed, false
-	 *  otherwise
-	 */
-	void set_simplify_internal_tet_facets(bool x) {
-	    simplify_internal_tet_facets_ = x;
-	}
+        /**
+         * \brief Specifies whether internal tetrahedron facets should be
+         *  removed.
+         * \details If set, a single polyhedron is generated for each
+         *  (connected component) of the restricted Voronoi cells. If not
+         *  set (default), each tetrahedron-Voronoi cell intersection 
+         *  generates a new polyhedron.  If set, this callback must be run
+         *  be run using connected components and not in parallel.
+         * \param[in] x true if internal facets should be removed, false
+         *  otherwise
+         */
+        void set_simplify_internal_tet_facets(bool x) {
+            simplify_internal_tet_facets_ = x;
+        }
 
-	/**
-	 * \brief Specifies whether Voronoi facets should be simplified.
-	 * \details By default, the computed Voronoi facets are composed
-	 *  of multiple polyhedra that correspond to the intersection with
-	 *  the tetrahedra of the input volume mesh. They can be simplified
-	 *  and replaced by a single polygon. This implies simplifying the
-	 *  internal tetrahedron facets and using a mesh.
-	 * \param[in] x true if Voronoi facets should be simplified, 
-	 *  false otherwise.
-	 */
-	void set_simplify_voronoi_facets(bool x) {
-	    simplify_voronoi_facets_ = x;
-	    if(x) {
-		set_simplify_internal_tet_facets(true);
-		set_use_mesh(true);
-	    }
-	}
+        /**
+         * \brief Specifies whether Voronoi facets should be simplified.
+         * \details By default, the computed Voronoi facets are composed
+         *  of multiple polyhedra that correspond to the intersection with
+         *  the tetrahedra of the input volume mesh. They can be simplified
+         *  and replaced by a single polygon. This implies simplifying the
+         *  internal tetrahedron facets and using a mesh.  If set, this 
+         *  callback must be run using connected components and not in 
+         *  parallel, unless simplify_internal_tet_facets and use_mesh are
+         *  subsequently set to false.
+         * \param[in] x true if Voronoi facets should be simplified, 
+         *  false otherwise.
+         */
+        void set_simplify_voronoi_facets(bool x) {
+            simplify_voronoi_facets_ = x;
+            if(x) {
+                set_simplify_internal_tet_facets(true);
+                set_use_mesh(true);
+            }
+        }
 
-	/**
-	 * \brief Specifies whether boundary facets should be simplified.
-	 * \details By default, the intersection between a Voronoi cell and
-	 *  the boundary is possibly composed of multiple polygons, that 
-	 *  correspond to the initial polygons of the boundary. They can be 
-	 *  simplified as a single polygon per Voronoi cell. This implies 
-	 *  simplifying the internal tetrahedron facets, simplifying the 
-	 *  Voronoi facets and using a mesh.
-	 * \param[in] x true if boundary facets should be simplified, 
-	 *  false otherwise.
-	 * \param[in] angle_threshold an edge shared by two adjacent facets 
-	 *  is suppressed if the angle between the facet normals is smaller 
-	 *  than \p angle_threshold
-	 */
-	void set_simplify_boundary_facets(bool x, double angle_threshold=45.0) {
-	    simplify_boundary_facets_ = x;
-	    if(x) {
-		set_simplify_voronoi_facets(true);
-		simplify_boundary_facets_angle_threshold_ = angle_threshold;
-	    } else {
-		simplify_boundary_facets_angle_threshold_ = 0.0;		
-	    }
-	}
+        /**
+         * \brief Specifies whether boundary facets should be simplified.
+         * \details By default, the intersection between a Voronoi cell and
+         *  the boundary is possibly composed of multiple polygons, that 
+         *  correspond to the initial polygons of the boundary. They can be 
+         *  simplified as a single polygon per Voronoi cell. This implies 
+         *  simplifying the internal tetrahedron facets, simplifying the 
+         *  Voronoi facets and using a mesh, and thus necessitates that the
+         *  callback be run using connected components and not in 
+         *  parallel.
+         * \param[in] x true if boundary facets should be simplified, 
+         *  false otherwise.
+         * \param[in] angle_threshold an edge shared by two adjacent facets 
+         *  is suppressed if the angle between the facet normals is smaller 
+         *  than \p angle_threshold
+         */
+        void set_simplify_boundary_facets(bool x, double angle_threshold=45.0) {
+            simplify_boundary_facets_ = x;
+            if(x) {
+                set_simplify_voronoi_facets(true);
+                simplify_boundary_facets_angle_threshold_ = angle_threshold;
+            } else {
+                simplify_boundary_facets_angle_threshold_ = 0.0;                
+            }
+        }
 
 	/**
 	 * \brief Specifies whether non-convex facets should be tessellated.
@@ -398,15 +401,16 @@ namespace GEO {
 	    tessellate_non_convex_facets_ = x;
 	}
 
-	
-	/**
-	 * \brief Specifies whether a mesh should be built for each
-	 *  traversed polyhedron.
-	 * \details The build mesh can then be modified (e.g., simplified)
-	 *  by overloading process_mesh().
-	 * \param[in] x true if a mesh should be build, false otherwise
-	 */
-	void set_use_mesh(bool x);
+        
+        /**
+         * \brief Specifies whether a mesh should be built for each
+         *  traversed polyhedron.
+         * \details The build mesh can then be modified (e.g., simplified)
+         *  by overloading process_mesh().  If this is true, the callback
+         *  must not be used in parallel.
+         * \param[in] x true if a mesh should be build, false otherwise
+         */
+        void set_use_mesh(bool x);
 
 	/**
 	 * \brief Sets the dimension of the internal mesh if need be.

--- a/src/lib/geogram/voronoi/generic_RVD.h
+++ b/src/lib/geogram/voronoi/generic_RVD.h
@@ -60,6 +60,10 @@
 #include <deque>
 #include <algorithm>
 #include <iostream>
+#include <atomic>
+
+#include "tbb/enumerable_thread_specific.h"
+#include "tbb/task.h"
 
 /**
  * \file geogram/voronoi/generic_RVD.h
@@ -379,9 +383,18 @@ namespace GEOGen {
 	 *  intersections.
 	 */
         PointAllocator* point_allocator() {
-	    return &intersections_;
-	}
-	
+            return &intersections_;
+        }
+
+       /**
+         * \brief Determines whether this should use tbb for multithreading.
+         * \details We generally want to use tbb, but when running Lloyd
+         *  iterations not in safe mode, it can exacerbate reproducibility
+         *  issues.
+         * \param[in] x whether to use tbb
+         */
+        void set_use_tbb(bool x) { use_tbb_ = x; }
+        
     protected:
         /**
          * \name Adapter classes for surfacic computation
@@ -419,7 +432,7 @@ namespace GEOGen {
                 const Polygon& P
             ) const {
                 GEO::geo_argused(f);
-                const_cast<ACTION&> ( do_it_)(v, P);
+                const_cast<ACTION&> ( do_it_)(v, f, P);
             }
 
         protected:
@@ -1080,7 +1093,7 @@ namespace GEOGen {
          * \brief Iterates on the facets of this RVD.
          * \param[in] action the user action object
          * \tparam ACTION needs to implement:
-         *  operator()(index_t v, index_t f, const Polygon& P) const
+         *  -operator()(index_t v, index_t f, const Polygon& P) const
          *  where v denotes the index of the current Voronoi cell
          *  (or Delaunay vertex), f the index of the current facet
          *  and P the computed intersection between facet f
@@ -1353,15 +1366,9 @@ namespace GEOGen {
                 facets_end_ = mesh_->facets.nb();
             }
             current_polygon_ = nullptr;
-            GEO::vector<index_t> seed_stamp(
-                delaunay_->nb_vertices(), index_t(-1)
-            );
-            GEO::vector<bool> facet_is_marked(facets_end_-facets_begin_, false);
             init_get_neighbors();
 
             FacetSeedStack adjacent_facets;
-            SeedStack adjacent_seeds;
-            Polygon F;
             GEO::Attribute<double> vertex_weight;
             vertex_weight.bind_if_is_defined(
 		mesh_->vertices.attributes(), "weight"
@@ -1370,81 +1377,209 @@ namespace GEOGen {
             // The algorithm propagates along both the facet-graph of
             // the surface and the 1-skeleton of the Delaunay triangulation,
             // and computes all the relevant intersections between
-            // each Voronoi cell and facet.
-            for(index_t f = facets_begin_; f < facets_end_; f++) {
-                if(!facet_is_marked[f-facets_begin_]) {
-                    // Propagate along the facet-graph.
-                    facet_is_marked[f-facets_begin_] = true;
-                    adjacent_facets.push(
-                        FacetSeed(f, find_seed_near_facet(f))
-                    );
-                    while(!adjacent_facets.empty()) {
-                        current_facet_ = adjacent_facets.top().f;
-                        current_seed_ = adjacent_facets.top().seed;
-                        adjacent_facets.pop();
+            // each Voronoi cell and facet.  How it does this depends on whether
+            // it is to be multithreaded via tbb or not.  This is done via two
+            // variadic arguments in the following lambda: 
+            // void propagate_facet(FacetSeed) will call this with a new 
+            // FacetSeed, possibly using tbb.
+            // bool test_and_set_facet(index_t) will (atomically if necessary)
+            // check if the corresponding facet (assuming that offsetting by 
+            // facets_begin_ was done before the call) has already been 
+            // accessed, and set it as accessed if not; it returns true if the 
+            // facet is changed, and false if not.
+            //
+            // Even if multithreading, the extra granularity of multithreading
+            // each facet is likely not worth the cost, so each facet will be
+            // all on a single thread.
 
-                        // Copy the current facet from the Mesh into
-                        // RestrictedVoronoiDiagram's Polygon data structure
-                        // (gathers all the necessary information)
-                        F.initialize_from_mesh_facet(
-                            mesh_, current_facet_, symbolic_, vertex_weight
-                        );
+            auto process_facet = [&vertex_weight, &action](
+                FacetSeed fs, thisclass& RVD, GEO::vector<index_t>& seed_stamp,
+                auto test_and_set_facet, auto propagate_facet) {
+                auto current_facet_ = fs.f;
+                auto current_seed_ = fs.seed;
 
-                        // Propagate along the Delaunay 1-skeleton
+                // Copy the current facet from the Mesh into
+                // RestrictedVoronoiDiagram's Polygon data structure
+                // (gathers all the necessary information)
+                Polygon F;
+                F.initialize_from_mesh_facet(
+                    RVD.mesh_, current_facet_, RVD.symbolic_, vertex_weight
+                );
+                // Propagate along the Delaunay 1-skeleton
                         // This will traverse all the seeds such that their
                         // Voronoi cell has a non-empty intersection with
                         // the current facet.
-                        seed_stamp[current_seed_] = current_facet_;
-                        adjacent_seeds.push(current_seed_);
+                seed_stamp[current_seed_] = current_facet_;
 
-                        while(!adjacent_seeds.empty()) {
-                            current_seed_ = adjacent_seeds.top();
-                            adjacent_seeds.pop();
+                SeedStack adjacent_seeds;
+                adjacent_seeds.push(current_seed_);
 
-                            current_polygon_ = intersect_cell_facet(
-                                current_seed_, F
-                            );
+                while (!adjacent_seeds.empty()) {
+                    current_seed_ = adjacent_seeds.top();
+                    adjacent_seeds.pop();
 
-                            action(
-                                current_seed_, current_facet_, current_polygon()
-                            );
+                    RVD.current_polygon_ = RVD.intersect_cell_facet(
+                        current_seed_, F
+                    );
 
-                            // Propagate to adjacent facets and adjacent seeds
-                            for(index_t v = 0;
-                                v < current_polygon().nb_vertices(); v++
+                    action(
+                        current_seed_, current_facet_, RVD.current_polygon()
+                    );
+
+                    // Propagate to adjacent facets and adjacent seeds
+                    for (index_t v = 0;
+                        v < RVD.current_polygon().nb_vertices(); v++
+                        ) {
+                        const Vertex& ve = RVD.current_polygon().vertex(v);
+                        signed_index_t neigh_f = ve.adjacent_facet();
+                        if (
+                            neigh_f >= signed_index_t(RVD.facets_begin_) &&
+                            neigh_f < signed_index_t(RVD.facets_end_) &&
+                            neigh_f != signed_index_t(current_facet_)
                             ) {
-                                const Vertex& ve = current_polygon().vertex(v);
-                                signed_index_t neigh_f = ve.adjacent_facet();
-                                if(
-                                    neigh_f >= signed_index_t(facets_begin_) &&
-                                    neigh_f < signed_index_t(facets_end_) &&
-                                    neigh_f != signed_index_t(current_facet_)
+                            if (test_and_set_facet(
+                                index_t(neigh_f) - RVD.facets_begin_)
                                 ) {
-                                    if(!facet_is_marked[
-                                           index_t(neigh_f)-facets_begin_
-                                    ]) {
-                                        facet_is_marked[
-                                            index_t(neigh_f)-facets_begin_
-                                        ] = true;
-                                        adjacent_facets.push(
-                                            FacetSeed(
-                                                index_t(neigh_f),
-                                                current_seed_
-                                            )
-                                        );
-                                    }
-                                }
-                                signed_index_t neigh_s = ve.adjacent_seed();
-                                if(neigh_s != -1) {
-                                    if(
-                                        seed_stamp[neigh_s] != current_facet_
-                                    ) {
-                                        seed_stamp[neigh_s] = current_facet_;
-                                        adjacent_seeds.push(index_t(neigh_s));
-                                    }
-                                }
+                                propagate_facet(
+                                    FacetSeed(
+                                        index_t(neigh_f),
+                                        current_seed_
+                                    )
+                                );
                             }
                         }
+                        signed_index_t neigh_s = ve.adjacent_seed();
+                        if (neigh_s != -1) {
+                            if (
+                                seed_stamp[neigh_s] != current_facet_
+                                ) {
+                                seed_stamp[neigh_s] = current_facet_;
+                                adjacent_seeds.push(index_t(neigh_s));
+                            }
+                        }
+                    }
+                }
+            };
+
+            if (!use_tbb_) {
+                GEO::vector<index_t> seed_stamp(
+                    delaunay_->nb_vertices(), index_t(-1)
+                );
+                GEO::vector<bool> facet_is_marked_(
+                    facets_end_ - facets_begin_, false
+                );
+                auto test_and_set_facet = [&facet_is_marked_](index_t f) {
+                    auto out = !facet_is_marked_[f];
+                    facet_is_marked_[f] = true;
+                    return out;
+                };
+                for (index_t f = facets_begin_; f < facets_end_; f++) {
+                    if (!facet_is_marked_[f - facets_begin_]) {
+                        // Propagate along the facet-graph.
+                        facet_is_marked_[f - facets_begin_] = true;
+                        adjacent_facets.push(
+                            FacetSeed(f, find_seed_near_facet(f))
+                        );
+                        auto propagate_facet = [&](FacetSeed fs) {
+                            adjacent_facets.push(fs);
+                        };
+                        while (!adjacent_facets.empty()) {
+                            auto current_facet_seed = adjacent_facets.top();
+                            adjacent_facets.pop();
+                            process_facet(
+                                current_facet_seed, *this, seed_stamp,
+                                test_and_set_facet, propagate_facet
+                            );
+                        }
+                    }
+                }
+            }
+            else {
+                auto copy_this = [this]() {
+                    return shallowCopy();
+                };
+                tbb::enumerable_thread_specific<thisclass> RVDs(copy_this);
+                auto make_seed_stamp = [this]() { return GEO::vector<index_t>(
+                        delaunay_->nb_vertices(), index_t(-1)
+                    );};
+                tbb::enumerable_thread_specific<GEO::vector<index_t>> 
+                    seed_stamps(make_seed_stamp);
+
+                // We can't use std::vector or GEO::vector for atomics because
+                // they are neither moveable nor copyable, but we can make a
+                // simple struct to handle it.
+
+                struct atomic_bool_vector {
+                    atomic_bool_vector(size_t size) 
+                        : ptr(new std::atomic_bool[size]()) {
+                        // Nothing to do; the () in the new-expression causes
+                        // the resulting values to all be set to false.
+                    }
+                    ~atomic_bool_vector() {
+                        delete[] ptr;
+                    }
+                    std::atomic_bool& operator[](size_t idx) { 
+                        return ptr[idx]; 
+                    }
+                    std::atomic_bool* ptr;
+                };
+
+                atomic_bool_vector facet_is_marked_(
+                    facets_end_ - facets_begin_
+                );
+
+                auto test_and_set_facet = [&facet_is_marked_](index_t f) {
+                    bool expected = false;
+                    return facet_is_marked_[f].compare_exchange_strong(
+                        expected, true, std::memory_order_relaxed
+                    );
+                };
+
+                for (index_t f = facets_begin_; f < facets_end_; f++) {
+                    if (test_and_set_facet(f - facets_begin_)) {
+                        // Propagate along the facet-graph, using a custom tbb
+                        // task.
+                        auto waiter_task = 
+                            new(tbb::task::allocate_root()) tbb::empty_task;                        
+
+                        struct FacetTaskData {
+                            decltype(RVDs)& taskRVDs;
+                            decltype(seed_stamps)& task_seed_stamps;
+                            decltype(process_facet)& process;
+                            decltype(test_and_set_facet)& test_and_set;
+                            decltype(waiter_task)& waiter;
+                        };
+
+                        struct FacetTask : tbb::task {
+                            FacetTask(FacetTaskData data, FacetSeed fs)
+                                : data(data), fs(fs) {}
+                            tbb::task* execute() override {                                
+                                auto propagate = [this](FacetSeed prop_fs) {
+                                    auto newTask =
+                                        new(tbb::task::
+                                            allocate_additional_child_of(
+                                            *data.waiter
+                                            )) FacetTask(data, prop_fs);
+                                    tbb::task::spawn(*newTask);
+                                };
+                                data.process(fs, data.taskRVDs.local(),
+                                    data.task_seed_stamps.local(),
+                                    data.test_and_set, propagate);
+                                return nullptr;
+                            }
+                            FacetTaskData data;
+                            FacetSeed fs;
+                        };
+
+                        FacetTaskData data{ RVDs, seed_stamps, process_facet,
+                                            test_and_set_facet, waiter_task };
+                        waiter_task->set_ref_count(2);
+
+                        auto first_facet_task =
+                            new(waiter_task->allocate_child())
+                            FacetTask(data,
+                                FacetSeed(f, find_seed_near_facet(f)));
+                        waiter_task->spawn_and_wait_for_all(*first_facet_task);
                     }
                 }
             }
@@ -1506,122 +1641,239 @@ namespace GEOGen {
             geo_assert(tets_begin_ != UNSPECIFIED_RANGE);
             geo_assert(tets_end_ != UNSPECIFIED_RANGE);
 
-            GEO::vector<index_t> seed_stamp(
-                delaunay_->nb_vertices(), index_t(-1)
-            );
-            GEO::vector<bool> tet_is_marked(tets_end_-tets_begin_, false);
+
             init_get_neighbors();
 
+            /////////////////////////////////
+
             TetSeedStack adjacent_tets;
-            SeedStack adjacent_seeds;
-            Polyhedron C(dimension());
             GEO::Attribute<double> vertex_weight;
             vertex_weight.bind_if_is_defined(
-		mesh_->vertices.attributes(), "weight"
-	    );
-            
-            current_polyhedron_ = &C;
+                mesh_->vertices.attributes(), "weight"
+            );
+
             // The algorithm propagates along both the facet-graph of
-            // the surface and the 1-skeleton of the Delaunay triangulation,
+            // the tet mesh and the 1-skeleton of the Delaunay triangulation,
             // and computes all the relevant intersections between
-            // each Voronoi cell and facet.
-            for(index_t t = tets_begin_; t < tets_end_; ++t) {
-                if(!tet_is_marked[t-tets_begin_]) {
-                    // Propagate along the tet-graph.
-                    tet_is_marked[t-tets_begin_] = true;
-                    adjacent_tets.push(
-                        TetSeed(t, find_seed_near_tet(t))
+            // each Voronoi cell and facet.  How it does this depends on whether
+            // it is to be multithreaded via tbb or not.  This is done via two
+            // variadic arguments in the following lambda: 
+            // void propagate_facet(FacetSeed) will call this with a new 
+            // FacetSeed, possibly using tbb.
+            // bool test_and_set_tet(index_t) will (atomically if necessary)
+            // check if the corresponding tet (assuming that offsetting by 
+            // tets_begin_ was done before the call) has already been 
+            // accessed, and set it as accessed if not; it returns true if the 
+            // tet is changed, and false if not.
+            //
+            // Even if multithreading, the extra granularity of multithreading
+            // each tet is likely not worth the cost, so each tet will be
+            // all on a single thread.
+
+            auto process_tet = [&vertex_weight, &action](
+                TetSeed ts, thisclass& RVD, GEO::vector<index_t>& seed_stamp,
+                auto test_and_set_tet, auto propagate_tet) {
+                auto current_tet_ = ts.f;
+                auto current_seed_ = ts.seed;
+
+                // Note: current cell could be looked up here,
+                // (from current_tet_) if we chose to keep it
+                // and copy it right before clipping (I am
+                // not sure that it is worth it, lookup time
+                // will be probably fast enough)
+
+                // Propagate along the Delaunay 1-skeleton
+                // This will traverse all the seeds such that their
+                // Voronoi cell has a non-empty intersection with
+                // the current facet.
+                seed_stamp[current_seed_] = current_tet_;
+
+                SeedStack adjacent_seeds;
+                adjacent_seeds.push(current_seed_);
+
+                while (!adjacent_seeds.empty()) {
+                    current_seed_ = adjacent_seeds.top();
+                    adjacent_seeds.pop();
+
+                    Polyhedron C(dimension());
+                    RVD.current_polyhedron_ = &C;
+
+                    C.initialize_from_mesh_tetrahedron(
+                        RVD.mesh_, current_tet_,
+                        RVD.symbolic_, vertex_weight
                     );
-                    while(!adjacent_tets.empty()) {
-                        current_tet_ = adjacent_tets.top().f;
-                        current_seed_ = adjacent_tets.top().seed;
-                        adjacent_tets.pop();
 
-                        // Note: current cell could be looked up here,
-                        // (from current_tet_) if we chose to keep it
-                        // and copy it right before clipping (I am
-                        // not sure that it is worth it, lookup time
-                        // will be probably fast enough)
+                    RVD.intersect_cell_cell(
+                        current_seed_, C
+                    );
 
-                        // Propagate along the Delaunay 1-skeleton
-                        // This will traverse all the seeds such that their
-                        // Voronoi cell has a non-empty intersection with
-                        // the current facet.
-                        seed_stamp[current_seed_] = current_tet_;
-                        adjacent_seeds.push(current_seed_);
+                    action(
+                        current_seed_, current_tet_,
+                        RVD.current_polyhedron()
+                    );
 
-                        while(!adjacent_seeds.empty()) {
-                            current_seed_ = adjacent_seeds.top();
-                            adjacent_seeds.pop();
+                    // Propagate to adjacent tets and adjacent seeds
+                    // Iterate on the vertices of the cell (remember:
+                    // the cell is represented in dual form)
+                    for (index_t v = 0;
+                        v < RVD.current_polyhedron().max_v(); ++v
+                        ) {
+                        //  Skip clipping planes that are no longer
+                        // connected to a cell facet.
+                        if (RVD.current_polyhedron().vertex_triangle(v) == -1) {
+                            continue;
+                        }
 
-                            C.initialize_from_mesh_tetrahedron(
-                                mesh_, current_tet_, symbolic_, vertex_weight
-                            );
+                        signed_index_t id =
+                            RVD.current_polyhedron().vertex_id(v);
+                        if (id > 0) {
+                            // Propagate to adjacent seed
+                            index_t neigh_s = index_t(id - 1);
+                            if (seed_stamp[neigh_s] != current_tet_) {
+                                seed_stamp[neigh_s] = current_tet_;
+                                adjacent_seeds.push(neigh_s);
+                            }
+                        }
+                        else if (id < 0) {
+                            // id==0 corresponds to facet on boundary (skipped)
+                            // id<0 corresponds to adjacent tet index
 
-                            intersect_cell_cell(
-                                current_seed_, C
-                            );
-
-                            action(
-                                current_seed_, current_tet_,
-                                current_polyhedron()
-                            );
-
-                            // Propagate to adjacent tets and adjacent seeds
-                            // Iterate on the vertices of the cell (remember:
-                            // the cell is represented in dual form)
-                            for(index_t v = 0;
-                                v < current_polyhedron().max_v(); ++v
-                            ) {
-
-                                //  Skip clipping planes that are no longer
-                                // connected to a cell facet.
-                                if(
-                                    current_polyhedron().vertex_triangle(v)
-                                    == -1
+                            // Propagate to adjacent tet
+                            signed_index_t neigh_t = -id - 1;
+                            if (
+                                neigh_t >=
+                                signed_index_t(RVD.tets_begin_) &&
+                                neigh_t < signed_index_t(RVD.tets_end_) &&
+                                neigh_t != signed_index_t(RVD.current_tet_)
                                 ) {
-                                    continue;
-                                }
-
-                                signed_index_t id =
-                                    current_polyhedron().vertex_id(v);
-                                if(id > 0) {
-                                    // Propagate to adjacent seed
-                                    index_t neigh_s = index_t(id - 1);
-                                    if(seed_stamp[neigh_s] != current_tet_) {
-                                        seed_stamp[neigh_s] = current_tet_;
-                                        adjacent_seeds.push(neigh_s);
-                                    }
-                                } else if(id < 0) {
-                                    // id==0 corresponds to facet on boundary
-                                    //  (skipped)
-                                    // id<0 corresponds to adjacent tet index
-
-                                    // Propagate to adjacent tet
-                                    signed_index_t neigh_t = -id - 1;
-                                    if(
-                                        neigh_t >=
-                                        signed_index_t(tets_begin_) &&
-                                        neigh_t <  signed_index_t(tets_end_) &&
-                                        neigh_t != signed_index_t(current_tet_)
+                                if (test_and_set_tet(
+                                    index_t(neigh_t) - RVD.tets_begin_)
                                     ) {
-                                        if(!tet_is_marked[
-                                               index_t(neigh_t)-tets_begin_
-                                        ]) {
-                                            tet_is_marked[
-                                                index_t(neigh_t)-tets_begin_
-                                            ] = true;
-                                            adjacent_tets.push(
-                                                TetSeed(
-                                                    index_t(neigh_t),
-                                                    current_seed_
-                                                )
-                                            );
-                                        }
-                                    }
+                                    propagate_tet(
+                                        TetSeed(index_t(neigh_t), current_seed_)
+                                    );
                                 }
                             }
                         }
+                    }
+                }
+            };
+
+            if (!use_tbb_) {
+                GEO::vector<index_t> seed_stamp(
+                    delaunay_->nb_vertices(), index_t(-1)
+                );
+                GEO::vector<bool> tet_is_marked(tets_end_ - tets_begin_, false);
+                auto test_and_set_tet = [&tet_is_marked](index_t t) {
+                    auto out = !tet_is_marked[t];
+                    tet_is_marked[t] = true;
+                    return out;
+                };
+                for (index_t t = tets_begin_; t < tets_end_; ++t) {
+                    if (!tet_is_marked[t - tets_begin_]) {
+                        // Propagate along the tet-graph.
+                        tet_is_marked[t - tets_begin_] = true;
+                        adjacent_tets.push(
+                            TetSeed(t, find_seed_near_tet(t))
+                        );
+                        auto propagate_tet = [&](TetSeed ts) {
+                            adjacent_tets.push(ts);
+                        };
+                        while (!adjacent_tets.empty()) {
+                            auto current_tet_seed = adjacent_tets.top();
+                            adjacent_tets.pop();
+                            process_tet(
+                                current_tet_seed, *this, seed_stamp,
+                                test_and_set_tet, propagate_tet
+                            );
+                        }
+                    }
+                }
+            }
+            else {
+                auto copy_this = [this]() {
+                    return shallowCopy();
+                };
+                tbb::enumerable_thread_specific<thisclass> RVDs(copy_this);
+                auto make_seed_stamp = [this]() { return GEO::vector<index_t>(
+                    delaunay_->nb_vertices(), index_t(-1)
+                    ); };
+                tbb::enumerable_thread_specific<GEO::vector<index_t>> 
+                    seed_stamps(make_seed_stamp);
+
+                // We can't use std::vector or GEO::vector for atomics because
+                // they are neither moveable nor copyable, but we can make a
+                // simple struct to handle it.
+
+                struct atomic_bool_vector {
+                    atomic_bool_vector(size_t size)
+                        : ptr(new std::atomic_bool[size]()) {
+                        // Nothing to do; the () in the new-expression causes
+                        // the resulting values to all be set to false.
+                    }
+                    ~atomic_bool_vector() {
+                        delete[] ptr;
+                    }
+                    std::atomic_bool& operator[](size_t idx) {
+                        return ptr[idx];
+                    }
+                    std::atomic_bool* ptr;
+                };
+
+                atomic_bool_vector tet_is_marked(tets_end_ - tets_begin_);
+
+                auto test_and_set_tet = [&tet_is_marked](index_t t) {
+                    bool expected = false;
+                    return tet_is_marked[t].compare_exchange_strong(
+                        expected, true, std::memory_order_relaxed
+                    );
+                };
+
+                for (index_t t = tets_begin_; t < tets_end_; t++) {
+                    if (test_and_set_tet(t - tets_begin_)) {
+                        // Propagate along the facet-graph, using a custom tbb
+                        // task.
+                        auto waiter_task =
+                            new(tbb::task::allocate_root()) tbb::empty_task;
+
+                        struct TetTaskData {
+                            decltype(RVDs)& taskRVDs;
+                            decltype(seed_stamps)& task_seed_stamps;
+                            decltype(process_tet)& process;
+                            decltype(test_and_set_tet)& test_and_set;
+                            decltype(waiter_task)& waiter;
+                        };
+
+                        struct TetTask : tbb::task {
+                            TetTask(TetTaskData data, TetSeed ts)
+                                : data(data), ts(ts) {}
+                            tbb::task* execute() override {
+                                auto propagate = [this](TetSeed prop_ts) {
+                                    auto newTask =
+                                        new(tbb::task::
+                                            allocate_additional_child_of(
+                                                *data.waiter
+                                            )) TetTask(data, prop_ts);
+                                    tbb::task::spawn(*newTask);
+                                };
+                                data.process(ts, data.taskRVDs.local(),
+                                    data.task_seed_stamps.local(),
+                                    data.test_and_set, propagate);
+                                return nullptr;
+                            }
+                            TetTaskData data;
+                            TetSeed ts;
+                        };
+
+                        TetTaskData data{ RVDs, seed_stamps, process_tet,
+                                          test_and_set_tet, waiter_task };
+                        waiter_task->set_ref_count(2);
+
+                        auto first_tet_task =
+                            new(waiter_task->allocate_child())
+                            TetTask(data,
+                                TetSeed(t, find_seed_near_tet(t)));
+                        waiter_task->spawn_and_wait_for_all(*first_tet_task);
                     }
                 }
             }
@@ -1872,8 +2124,9 @@ namespace GEOGen {
          * that computes the final surface in CVT (i.e., the dual of the
          * connected components).
          * \note This function is less efficient than
-         *  compute_surfacic_with_seeds_priority() but
-         *  is required by some traversals that need to be done in that order.
+         *  compute_surfacic_with_seeds_priority() and does not allow for use
+         *  of tbb for multithreading, but is required by some traversals that
+         *  need to be done in that order.
          * \tparam ACTION needs to implement:
          *  operator()(index_t v, index_t f, const Polygon& P) const
          *  where v denotes the index of the current Voronoi cell
@@ -2297,6 +2550,29 @@ namespace GEOGen {
             }
         }
 
+        /**
+          * \brief Returns a shallow copy.
+          *
+          * \details This function returns a copy that references the same mesh
+          *  and delaunay structure; other pointers are cleared entirely.
+          */
+        RestrictedVoronoiDiagram shallowCopy() const {
+            auto out = *this;
+            out.current_polyhedron_ = nullptr;
+            out.current_polygon_ = nullptr;
+            out.facet_seed_marking_ = nullptr;
+            return out;
+        }
+
+        /**
+          * \brief Move constructor.
+          *
+          * \details The copy constructor is private to force use of
+          *  shallowCopy(), but a move constructor is needed regardless, and
+          *  is harmless since moves are "shallow" by default.
+          */
+        RestrictedVoronoiDiagram(thisclass&& rhs) = default;
+
     protected:
         /**
          * \brief Computes the intersection between a Voronoi cell
@@ -2505,11 +2781,14 @@ namespace GEOGen {
         bool connected_component_changed_;
         index_t current_connected_component_;
 
+        bool use_tbb_ = true;
+
     private:
         /**
-         * \brief Forbids construction from copy.
+         * \brief Forbids outside construction from copy; use shallow_copy() 
+         *  instead.
          */
-        RestrictedVoronoiDiagram(const thisclass& rhs);
+        RestrictedVoronoiDiagram(const thisclass& rhs) = default;
 
         /**
          * \brief Forbids assignment.


### PR DESCRIPTION
Because we want to update geogram in general...and because it currently does not compile on gcc11. I reverted an indentation commit that was making the merging process significantly harder.

Jérémie <3

I've been spending a small amount of time at updating geogram (to solve some compilation issues). I noticed that one commit was making it a nightmare to update geogram. I made a branch that undoes that commit. However, I did it by cherry-picking all other commits, so this would require changing the effective geogram branch. I also was able to (without much effort) update to the latest geogram. I have a PR with the first part (without the update) up in https://github.com/nTopology/geogram/pull/15 .
[@Suraj](https://ntopology.slack.com/team/URY085GR0)
et al, let me know what you thing. I'm still working on fixing geogram to compile in gcc-11.