### PR TITLE
TUR-13868: Return null ostream in logger

### DIFF
--- a/src/lib/geogram/basic/logger.cpp
+++ b/src/lib/geogram/basic/logger.cpp
@@ -64,6 +64,14 @@
 
 namespace GEO {
 
+  namespace {
+    class NullBuffer : public std::streambuf
+    {
+      public:
+        int overflow(int c) { return c; }
+      };
+    }
+
     /************************************************************************/
 
     int LoggerStreamBuf::sync() {
@@ -381,12 +389,10 @@ namespace GEO {
         return result;
     }
 
-    std::ostream& Logger::out(const std::string& feature) {
-        std::ostream& result =
-            (is_initialized() && !Process::is_running_threads()) ?
-            instance()->out_stream(feature) :
-            (std::cerr << "    [" << feature << "] ");
-        return result;
+    std::ostream& Logger::out(const std::string&) {
+        static NullBuffer nullBuffer;
+        static std::ostream stream(&nullBuffer);
+        return stream;
     }
 
     std::ostream& Logger::err(const std::string& feature) {


### PR DESCRIPTION
The logger is not thread-safe, even if set to quiet. That is because log messages are always pushed into a global string buffer that is shared across threads. geograms mitigates this by logging to `cerr `in case `Process::is_running_threads()` is turned on. In that case users of ntop will see logging messages, even though we turned the logger to quiet. Otoh if multiple blocks call into geograms logging facilities we might end up with a crash, because the logging is not thread safe and `is_running_threads` is false.