### PR TITLE
TUR-12465 - Fix crash due to integer division by zero.

### DIFF
--- a/src/lib/geogram/voronoi/RVD.cpp
+++ b/src/lib/geogram/voronoi/RVD.cpp
@@ -2769,7 +2769,7 @@ namespace {
                     static_cast<index_t>(std::log2(
                         mesh_->facets.nb() + mesh_->cells.nb()
                     ));
-                nb_parts_in = std::fmax(1, nb_parts_in);
+                nb_parts_in = std::max(GEO::index_t(1), nb_parts_in);
                 vector<index_t> facet_ptr;
                 vector<index_t> tet_ptr;
                 mesh_partition(

--- a/src/lib/geogram/voronoi/RVD.cpp
+++ b/src/lib/geogram/voronoi/RVD.cpp
@@ -2769,6 +2769,7 @@ namespace {
                     static_cast<index_t>(std::log2(
                         mesh_->facets.nb() + mesh_->cells.nb()
                     ));
+                nb_parts_in = std::fmax(1, nb_parts_in);
                 vector<index_t> facet_ptr;
                 vector<index_t> tet_ptr;
                 mesh_partition(


### PR DESCRIPTION
This is [TUR-12465](https://ntopology.atlassian.net/browse/TUR-12465)

This is happening In RVD.cpp, where the threads are created before sampling the mesh, I think by partitioning the mesh and assigning partitions to threads. 

The number of parititions nb_parts_in for the case of a single triangle turns out to just be 1, so its log 2 is just zero. This then leads to an integer divide by zero, which crashes nTop. Zero partitions/threads also doesn’t make much sense. Making sure it's at least 1 fixes this

![image](https://user-images.githubusercontent.com/101139752/195694920-ab1c18a1-c817-49b7-b49f-2927bcf59afd.png)
