### PR TITLE
route all assertion failures through Logger

### DIFF
--- a/src/lib/geogram/basic/assert.cpp
+++ b/src/lib/geogram/basic/assert.cpp
@@ -112,17 +112,13 @@ namespace GEO {
         os << "File: " << file << ",\n";
         os << "Line: " << line;
 
+        Logger::err("Assert") << os.str() << std::endl;
+
         if(assert_mode_ == ASSERT_THROW) {
-            if(Logger::instance()->is_quiet()) {
-                std::cerr << os.str()
-                          << std::endl;
-            }
             throw std::runtime_error(os.str());
         } else if(assert_mode_ == ASSERT_ABORT) {
-            Logger::err("Assert") << os.str() << std::endl;
             geo_abort();
         } else {
-            Logger::err("Assert") << os.str() << std::endl;
             geo_breakpoint();
         }
     }
@@ -137,14 +133,11 @@ namespace GEO {
         os << "File: " << file << ",\n";
         os << "Line: " << line;
 
+        Logger::err("Assert") << os.str() << std::endl;
+
         if(assert_mode_ == ASSERT_THROW) {
-            if(Logger::instance()->is_quiet()) {
-                std::cerr << os.str()
-                          << std::endl;
-            }
             throw std::runtime_error(os.str());
         } else {
-            Logger::err("Assert") << os.str() << std::endl;
             geo_abort();
         }
     }
@@ -157,14 +150,11 @@ namespace GEO {
         os << "File: " << file << ",\n";
         os << "Line: " << line;
 
+        Logger::err("Assert") << os.str() << std::endl;
+
         if(assert_mode_ == ASSERT_THROW) {
-            if(Logger::instance()->is_quiet()) {
-                std::cerr << os.str()
-                          << std::endl;
-            }
             throw std::runtime_error(os.str());
         } else {
-            Logger::err("Assert") << os.str() << std::endl;
             geo_abort();
         }
     }


### PR DESCRIPTION
partially fixes: https://github.com/nTopology/turbo/issues/17151#issuecomment-3643818232
encompanies: https://github.com/nTopology/turbo/pull/17175

* Previously, in release when assert mode was set to `ASSERT_THROW` and the logger was in "quiet" mode, geogram bypassed the `Logger` subsystem and wrote directly to `std::cerr`. This behavior is problematic for us downstream because it is leaking those assertion messages to the user-facing terminal session. 
* No raw output is leaked to `std::cerr`.
* If the exception is thrown (`ASSERT_THROW`), the message is available via the exception object, avoiding "double logging" (once to stderr, once via the exception catcher).

<img width="1720" height="110" alt="image" src="https://github.com/user-attachments/assets/1b5c4615-3fee-46d0-a687-c20a705c6893" />

Testing Summary:
1. new unit test: test_degenerate_skewness_assert in test_ntsim should no longer leak the assertion message
2. [turbo_17151_mesh_quality_test.ntop](https://drive.google.com/file/d/1ZcFXtwVpF0M0QjWG98PR0DZJULhFIewQ/view?usp=drive_link) should no longer leak the assertion message.
3. the assertion message should still be visible in the ntop debug log.